### PR TITLE
Add support for "count" in symex-ts primitives

### DIFF
--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -45,7 +45,7 @@ This procedure is not to be used except in the low-level internals
 of symex mode (use the public `symex-go-forward` instead)."
   (interactive)
   (if tree-sitter-mode
-      (symex-ts-move-next-sibling)
+      (symex-ts-move-next-sibling count)
     (symex-lisp--forward count)))
 
 (defun symex--backward (&optional count)
@@ -60,7 +60,7 @@ This procedure is not to be used except in the low-level internals
 of symex mode (use the public `symex-go-backward` instead)."
   (interactive)
   (if tree-sitter-mode
-      (symex-ts-move-prev-sibling)
+      (symex-ts-move-prev-sibling count)
     (symex-lisp--backward count)))
 
 (defun symex--enter (&optional count)
@@ -75,7 +75,7 @@ This procedure is not to be used except in the low-level internals
 of symex mode (use the public `symex-go-up` instead)."
   (interactive)
   (if tree-sitter-mode
-      (symex-ts-move-child)
+      (symex-ts-move-child count)
     (symex-lisp--enter count)))
 
 (defun symex--exit (&optional count)
@@ -90,7 +90,7 @@ This procedure is not to be used except in the low-level internals
 of symex mode (use the public `symex-go-down` instead)."
   (interactive)
   (if tree-sitter-mode
-      (symex-ts-move-parent)
+      (symex-ts-move-parent count)
     (symex-lisp--exit count)))
 
 


### PR DESCRIPTION
### Summary of Changes

symex-ts now supports an optional "count" argument for basic movements.

See [5f6652a699aea4ff539715b5468bfb2b43d88345](https://github.com/polaris64/symex-ts/commit/5f6652a699aea4ff539715b5468bfb2b43d88345)

### Public Domain Dedication

- [✓] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
