### PR TITLE
Add support for non-Lisp languages by using tree-sitter

### DIFF
--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -91,7 +91,7 @@ Syntax
 Description
 ```````````
 
-Execute a sequence of traversals in order. If the maneuver is partially completed, i.e. if at least one traversal was executed, then the maneuver is treated as successful. Otherwise it is considered to have failed.
+Execute a sequence of traversals in order. The maneuver succeeds if *all* of the traversals succeed. If any of them fail, then the entire maneuver is aborted and nothing happens. In other words, the maneuver has "all or nothing" semantics. To accept partial completion, use ``venture`` instead.
 
 Examples
 ````````
@@ -115,6 +115,42 @@ Examples
       (maneuver (maneuver (move up)
                           (circuit (move forward)))
                 (move up))))
+
+venture
+~~~~~~~
+
+Syntax
+``````
+
+``(venture traversal ...)``
+
+Description
+```````````
+
+Execute a sequence of traversals in order. If the venture is partially completed, i.e. if at least one traversal was executed, then the venture is treated as successful. Otherwise it is considered to have failed.
+
+Examples
+````````
+
+"Venture to go forward, then up, and then forward again."
+
+::
+
+  (symex-execute-traversal
+    (symex-traversal
+      (venture (move forward)
+               (move up)
+               (move forward))))
+
+"Venture to go up and then keep going forward, and then go up again."
+
+::
+
+  (symex-execute-traversal
+    (symex-traversal
+      (venture (venture (move up)
+                        (circuit (move forward)))
+               (move up))))
 
 protocol
 ~~~~~~~~
@@ -269,8 +305,8 @@ Examples
     (symex-traversal
       (circuit
         (precaution
-          (maneuver (move down)
-                    (move forward))
+          (venture (move down)
+                   (move forward))
           (afterwards (not (at root)))))))
 
 precaution
@@ -414,6 +450,6 @@ Also see `this series on ELisp debugging <https://endlessparentheses.com/debuggi
 Gotchas
 ^^^^^^^
 
-The ``symex-traversal`` form accepts a *single* traversal argument. If you'd like to do more than one thing, then wrap the steps in a `maneuver`_.
+The ``symex-traversal`` form accepts a *single* traversal argument. If you'd like to do more than one thing, then wrap the steps in a `maneuver`_ or a `venture`_.
 
 ``symex-deftraversal`` is equivalent to ``(defvar name (symex-traversal traversal))``. As it uses ``defvar``, once defined, you cannot use the same form to redefine the traversal (e.g. if you are debugging it). You will need to use ``setq`` directly -- e.g. replace ``defvar`` with ``setq`` in the expanded version of this form.

--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -447,6 +447,18 @@ When you're done debugging, you can remove the debugger hooks by just evaluating
 
 Also see `this series on ELisp debugging <https://endlessparentheses.com/debugging-emacs-lisp-part-1-earn-your-independence.html>`__ for more tips.
 
+Print Statements and Asserts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Don't hesitate to add print statements (e.g. ``message``) to trace the execution path. Such trace logs can also serve as evidence from which to form hypotheses about bugs. You could also use ``cl-assert`` to assert assumptions at specific points.
+
+Minimizing Complexity
+^^^^^^^^^^^^^^^^^^^^^
+
+Symex uses advice to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
+
+It may also be advisable to comment out macros like ``symex-save-excursion`` to see if the problem persists.
+
 Gotchas
 ^^^^^^^
 

--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -455,7 +455,7 @@ Don't hesitate to add print statements (e.g. ``message``) to trace the execution
 Minimizing Complexity
 ^^^^^^^^^^^^^^^^^^^^^
 
-Symex uses advice to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
+Symex uses `advice <https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html>`_ to implement some features such as branch memory. To minimize complexity while debugging, it may be advisable (so to speak) to disable such advice. To do this, find the place in the code where the advice is added and execute the corresponding function to remove it, something like ``(advice-remove #'symex-go-down #'symex--remember-branch-position)``. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation.
 
 It may also be advisable to comment out macros like ``symex-save-excursion`` to see if the problem persists.
 

--- a/dev/dev-utils.el
+++ b/dev/dev-utils.el
@@ -17,18 +17,61 @@
 ;; Symex-TS hydra: useful for debugging Tree Sitter movements outside
 ;; of the rest of Symex.
 
+(defface symex-ts-current-node-face
+  '((t :inherit highlight :extend nil))
+  "Face used to highlight the current tree node."
+  :group 'symex-faces)
+
+(defvar symex-ts--current-overlay nil "The current overlay which highlights the current node.")
+
+(defun symex-ts--delete-overlay ()
+  "Delete the highlight overlay."
+  (when symex-ts--current-overlay
+    (delete-overlay symex-ts--current-overlay)))
+
+(defun symex-ts--update-overlay (node)
+  "Update the highlight overlay to match the start/end position of NODE."
+  (when symex-ts--current-overlay
+    (delete-overlay symex-ts--current-overlay))
+  (setq-local symex-ts--current-overlay (make-overlay (tsc-node-start-position node) (tsc-node-end-position node)))
+  (overlay-put symex-ts--current-overlay 'face 'symex-ts-current-node-face))
+
 (defun symex-ts--hydra-exit ()
   "Handle Hydra exit."
   (symex-ts--delete-overlay))
+
+(defun symex-ts--move-next ()
+  "Move to next sibling."
+  (interactive)
+  (symex-ts-move-next-sibling)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-previous ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-prev-sibling)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-parent ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-parent)
+  (symex-ts--update-overlay symex-ts--current-node))
+
+(defun symex-ts--move-child ()
+  "Move to previous sibling."
+  (interactive)
+  (symex-ts-move-child)
+  (symex-ts--update-overlay symex-ts--current-node))
 
 (defhydra hydra-symex-ts (:post (symex-ts--hydra-exit))
   "Symex-TS."
   ("d" symex-ts-current-node-sexp "DEBUG NODE")
 
-  ("h" symex-ts-move-prev-sibling "prev")
-  ("l" symex-ts-move-next-sibling "next")
-  ("j" symex-ts-move-parent "parent")
-  ("k" symex-ts-move-child "child"))
+  ("h" symex-ts--move-previous "prev")
+  ("l" symex-ts--move-next "next")
+  ("j" symex-ts--move-parent "parent")
+  ("k" symex-ts--move-child "child"))
 
 (defun symex-ts-launch ()
   "Start the Symex-TS hydra."
@@ -36,6 +79,7 @@
 
   ;; Set the current node to the top-most node at point
   (symex-ts-set-current-node-from-point)
+  (symex-ts--update-overlay symex-ts--current-node)
 
   ;; Launch hydra
   (hydra-symex-ts/body))

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -36,7 +36,7 @@
   :group 'symex)
 
 (defcustom symex-refocus-p t
-  "Whether to refocus on the selected symex when it's close to the edge of the screen."
+  "Whether to refocus on the selected symex when it's near the screen's edge."
   :type 'boolean
   :group 'symex)
 

--- a/symex-data.el
+++ b/symex-data.el
@@ -166,6 +166,41 @@ This is useful for structural recursion during circuit execution."
         (times (symex--circuit-times circuit)))
     (symex-make-circuit traversal (when times (1- times)))))
 
+(defun symex-make-maneuver (&rest phases)
+  "Construct a maneuver from the given PHASES."
+  (list 'maneuver
+        phases))
+
+(defun symex-maneuver-p (obj)
+  "Check if OBJ specifies a maneuver."
+  (condition-case nil
+      (equal 'maneuver
+             (nth 0 obj))
+    (error nil)))
+
+(defun symex--maneuver-phases (maneuver)
+  "Get the phases of a MANEUVER.
+
+Each phase could be any traversal."
+  (nth 1 maneuver))
+
+(defun symex--maneuver-null-p (maneuver)
+  "Check if MANEUVER is empty or null."
+  (null (symex--maneuver-phases maneuver)))
+
+(defun symex--maneuver-first (maneuver)
+  "Get the first phase of a MANEUVER.
+
+This is useful for structural recursion during maneuver execution."
+  (car (symex--maneuver-phases maneuver)))
+
+(defun symex--maneuver-rest (maneuver)
+  "A maneuver defined from the remaining phases in MANEUVER not counting the first.
+
+This is useful for structural recursion during maneuver execution."
+  (apply #'symex-make-maneuver
+         (cdr (symex--maneuver-phases maneuver))))
+
 (defun symex-make-venture (&rest phases)
   "Construct a venture from the given PHASES."
   (list 'venture
@@ -307,6 +342,7 @@ This is the traversal that will be chosen if the condition is false."
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)
+      (symex-maneuver-p obj)
       (symex-venture-p obj)
       (symex-circuit-p obj)
       (symex-detour-p obj)

--- a/symex-data.el
+++ b/symex-data.el
@@ -56,6 +56,10 @@ forward-backward axis, and the Y or in-out axis."
     (error nil)))
 
 (defconst symex--move-zero (symex-make-move 0 0))
+(defconst symex--move-forward (symex-make-move 1 0))
+(defconst symex--move-backward (symex-make-move -1 0))
+(defconst symex--move-down (symex-make-move 0 -1))
+(defconst symex--move-up (symex-make-move 0 1))
 
 (defun symex--are-moves-equal-p (m1 m2)
   "Check if two moves M1 and M2 are identical."

--- a/symex-data.el
+++ b/symex-data.el
@@ -22,8 +22,8 @@
 ;;; Commentary:
 
 ;; Data abstractions for symex mode.  Defines the linguistic primitives
-;; of the symex DSL: moves, maneuvers, precautions, protocols,
-;; circuits, and detours.
+;; of the symex DSL: moves, maneuvers, ventures, precautions, protocols,
+;; decisions, circuits, and detours.
 
 ;;; Code:
 
@@ -166,40 +166,40 @@ This is useful for structural recursion during circuit execution."
         (times (symex--circuit-times circuit)))
     (symex-make-circuit traversal (when times (1- times)))))
 
-(defun symex-make-maneuver (&rest phases)
-  "Construct a maneuver from the given PHASES."
-  (list 'maneuver
+(defun symex-make-venture (&rest phases)
+  "Construct a venture from the given PHASES."
+  (list 'venture
         phases))
 
-(defun symex-maneuver-p (obj)
-  "Check if OBJ specifies a maneuver."
+(defun symex-venture-p (obj)
+  "Check if OBJ specifies a venture."
   (condition-case nil
-      (equal 'maneuver
+      (equal 'venture
              (nth 0 obj))
     (error nil)))
 
-(defun symex--maneuver-phases (maneuver)
-  "Get the phases of a MANEUVER.
+(defun symex--venture-phases (venture)
+  "Get the phases of a VENTURE.
 
 Each phase could be any traversal."
-  (nth 1 maneuver))
+  (nth 1 venture))
 
-(defun symex--maneuver-null-p (maneuver)
-  "Check if MANEUVER is empty or null."
-  (null (symex--maneuver-phases maneuver)))
+(defun symex--venture-null-p (venture)
+  "Check if VENTURE is empty or null."
+  (null (symex--venture-phases venture)))
 
-(defun symex--maneuver-first (maneuver)
-  "Get the first phase of a MANEUVER.
+(defun symex--venture-first (venture)
+  "Get the first phase of a VENTURE.
 
-This is useful for structural recursion during maneuver execution."
-  (car (symex--maneuver-phases maneuver)))
+This is useful for structural recursion during venture execution."
+  (car (symex--venture-phases venture)))
 
-(defun symex--maneuver-rest (maneuver)
-  "A maneuver defined from the remaining phases in MANEUVER not counting the first.
+(defun symex--venture-rest (venture)
+  "A venture defined from the remaining phases in VENTURE not counting the first.
 
-This is useful for structural recursion during maneuver execution."
-  (apply #'symex-make-maneuver
-         (cdr (symex--maneuver-phases maneuver))))
+This is useful for structural recursion during venture execution."
+  (apply #'symex-make-venture
+         (cdr (symex--venture-phases venture))))
 
 (defun symex-make-detour (reorientation traversal)
   "Construct a detour.
@@ -234,7 +234,7 @@ fails as well."
 (defun symex-make-protocol (&rest options)
   "Construct a protocol abstraction for the given OPTIONS.
 
-An option could be either a maneuver, or a protocol itself."
+Each option could be any traversal."
   (list 'protocol
         options))
 
@@ -307,7 +307,7 @@ This is the traversal that will be chosen if the condition is false."
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)
-      (symex-maneuver-p obj)
+      (symex-venture-p obj)
       (symex-circuit-p obj)
       (symex-detour-p obj)
       (symex-precaution-p obj)

--- a/symex-data.el
+++ b/symex-data.el
@@ -159,9 +159,11 @@ This is the number of times the traversal should be repeated."
     (and times (zerop times))))
 
 (defun symex--circuit-rest (circuit)
-  "A circuit defined from the remaining repetitions of the traversal in CIRCUIT, not counting the first.
+  "A circuit defined from the remaining repetitions of the traversal.
 
-This is useful for structural recursion during circuit execution."
+This includes the remaining repetitions in CIRCUIT, not counting the
+first. This is useful for structural recursion during circuit
+execution."
   (let ((traversal (symex--circuit-traversal circuit))
         (times (symex--circuit-times circuit)))
     (symex-make-circuit traversal (when times (1- times)))))

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -219,6 +219,7 @@ This can be thought of as the 'program' written in the DSL, which
 will be compiled into Lisp and can be executed when needed.
 An optional DOCSTRING will be used as documentation for the variable
 NAME to which the traversal is assigned."
+  (declare (indent 1))
   `(defvar ,name (symex-traversal ,traversal) ,docstring))
 
 

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -40,11 +40,11 @@ OPTIONS - see underlying Lisp implementation."
   `(symex-make-protocol
     ,@(mapcar #'symex--compile-traversal-helper options)))
 
-(defmacro symex--compile-maneuver (&rest phases)
-  "Compile a maneuver from Symex DSL -> Lisp.
+(defmacro symex--compile-venture (&rest phases)
+  "Compile a venture from Symex DSL -> Lisp.
 
 PHASES - see underlying Lisp implementation."
-  `(symex-make-maneuver
+  `(symex-make-venture
     ,@(mapcar #'symex--compile-traversal-helper phases)))
 
 (defmacro symex--compile-detour (reorientation traversal)
@@ -195,8 +195,8 @@ a detour, a move, etc., which is specified using the Symex DSL."
   (cond ((not (listp traversal)) traversal)  ; e.g. a variable containing a traversal
         ((equal 'protocol (car traversal))
          `(symex--compile-protocol ,@(cdr traversal)))
-        ((equal 'maneuver (car traversal))
-         `(symex--compile-maneuver ,@(cdr traversal)))
+        ((equal 'venture (car traversal))
+         `(symex--compile-venture ,@(cdr traversal)))
         ((equal 'detour (car traversal))
          `(symex--compile-detour ,@(cdr traversal)))
         ((equal 'circuit (car traversal))

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -40,6 +40,13 @@ OPTIONS - see underlying Lisp implementation."
   `(symex-make-protocol
     ,@(mapcar #'symex--compile-traversal-helper options)))
 
+(defmacro symex--compile-maneuver (&rest phases)
+  "Compile a maneuver from Symex DSL -> Lisp.
+
+PHASES - see underlying Lisp implementation."
+  `(symex-make-maneuver
+    ,@(mapcar #'symex--compile-traversal-helper phases)))
+
 (defmacro symex--compile-venture (&rest phases)
   "Compile a venture from Symex DSL -> Lisp.
 
@@ -195,6 +202,8 @@ a detour, a move, etc., which is specified using the Symex DSL."
   (cond ((not (listp traversal)) traversal)  ; e.g. a variable containing a traversal
         ((equal 'protocol (car traversal))
          `(symex--compile-protocol ,@(cdr traversal)))
+        ((equal 'maneuver (car traversal))
+         `(symex--compile-maneuver ,@(cdr traversal)))
         ((equal 'venture (car traversal))
          `(symex--compile-venture ,@(cdr traversal)))
         ((equal 'detour (car traversal))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -133,22 +133,22 @@ The aggregate result is constructed according to the specified COMPUTATION."
            a
            b))
 
-(defun symex-execute-maneuver (maneuver computation)
-  "Attempt to execute a given MANEUVER.
+(defun symex-execute-venture (venture computation)
+  "Attempt to execute a given VENTURE.
 
-Attempts the maneuver in the order of its phases.  If any phase fails,
-then the maneuver is terminated at that step.  The maneuver succeeds
+Attempts the venture in the order of its phases.  If any phase fails,
+then the venture is terminated at that step.  The venture succeeds
 if at least one phase succeeds, and otherwise fails.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (unless (symex--maneuver-null-p maneuver)
-    (let ((current-phase (symex--maneuver-first maneuver))
-          (remaining-maneuver (symex--maneuver-rest maneuver)))
+  (unless (symex--venture-null-p venture)
+    (let ((current-phase (symex--venture-first venture))
+          (remaining-venture (symex--venture-rest venture)))
       (let ((executed-phase (symex-execute-traversal current-phase
                                                      computation)))
         (when executed-phase
           (let ((executed-remaining-phases
-                 (symex-execute-traversal remaining-maneuver
+                 (symex-execute-traversal remaining-venture
                                           computation)))
             (symex--compute-results executed-phase
                                     executed-remaining-phases
@@ -267,9 +267,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
           (original-point-height-offset
            (symex-save-excursion
             (symex--point-height-offset)))
-          (executed-traversal (cond ((symex-maneuver-p traversal)
-                                     (symex-execute-maneuver traversal
-                                                             computation))
+          (executed-traversal (cond ((symex-venture-p traversal)
+                                     (symex-execute-venture traversal
+                                                            computation))
                                     ((symex-circuit-p traversal)
                                      (symex-execute-circuit traversal
                                                             computation))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -56,7 +56,8 @@ requiring changes to higher-level code that uses the present interface."
           ((> move-y 0)
            (symex--enter move-y))
           ((< move-y 0)
-           (symex--exit (abs move-y))))))
+           (symex--exit (abs move-y)))
+          (t symex--move-zero))))
 
 (defun symex-execute-move (move &optional computation)
   "Execute the MOVE as a traversal.

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -50,13 +50,13 @@ requiring changes to higher-level code that uses the present interface."
   (let ((move-x (symex--move-x move))
         (move-y (symex--move-y move)))
     (cond ((> move-x 0)
-           (symex--forward move-x))
+           (symex--go-forward move-x))
           ((< move-x 0)
-           (symex--backward (abs move-x)))
+           (symex--go-backward (abs move-x)))
           ((> move-y 0)
-           (symex--enter move-y))
+           (symex--go-up move-y))
           ((< move-y 0)
-           (symex--exit (abs move-y)))
+           (symex--go-down (abs move-y)))
           (t symex--move-zero))))
 
 (defun symex-execute-move (move &optional computation)
@@ -68,38 +68,6 @@ Optional argument COMPUTATION currently unused."
   (let ((executed-move (symex--execute-tree-move move computation)))
     (when executed-move
       (list executed-move))))
-
-(cl-defun symex--go-forward (&optional (count 1))
-  "Move forward COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move count 0)))
-
-(cl-defun symex--go-backward (&optional (count 1))
-  "Move backwards COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move (- count) 0)))
-
-(cl-defun symex--go-up (&optional (count 1))
-  "Move up COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move 0 count)))
-
-(cl-defun symex--go-down (&optional (count 1))
-  "Move down COUNT symexes.
-
-This is an internal utility that avoids any user-level concerns
-such as symex selection via advice.  This should be used in all
-internal operations that are not primarily user-directed."
-  (symex--execute-tree-move (symex-make-move 0 (- count))))
 
 (cl-defun symex-go-forward (&optional (count 1))
   "Move forward COUNT symexes."

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -292,6 +292,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
+          (symex-select-nearest)
           (let* ((current-point-height-offset (symex--point-height-offset))
                  (height-differential (- original-point-height-offset
                                          current-point-height-offset)))

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -266,7 +266,14 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         (side-effect (if side-effect
                          side-effect
                        #'symex--side-effect-noop)))
+    ;; TODO: a macro similar to `symex-save-excursion`
+    ;; where it conditionally returns to the original
+    ;; point / node depending on whether BODY succeeds
+    ;; or which tests for success before moving point
     (let ((original-location (point))
+          (original-point-height-offset
+           (symex-save-excursion
+            (symex--point-height-offset)))
           (executed-traversal (cond ((symex-maneuver-p traversal)
                                      (symex-execute-maneuver traversal
                                                              computation))
@@ -295,6 +302,14 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
+          (let* ((current-point-height-offset
+                  (symex-save-excursion
+                   (symex--point-height-offset)))
+                 (height-differential (- original-point-height-offset
+                                         current-point-height-offset)))
+            ;; necessary because point does not uniquely identify
+            ;; a node for non-symex (i.e. tree-sitter) languages
+            (symex--go-up height-differential))
           result)))))
 
 

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -140,7 +140,8 @@ Attempts the maneuver in the order of its phases.  The maneuver
 succeeds only if all of the phases succeed, and otherwise fails.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (unless (symex--maneuver-null-p maneuver)
+  (if (symex--maneuver-null-p maneuver)
+      symex--move-zero
     (let ((current-phase (symex--maneuver-first maneuver))
           (remaining-maneuver (symex--maneuver-rest maneuver)))
       (let ((executed-phase (symex-execute-traversal current-phase
@@ -151,7 +152,10 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                           computation)))
             (when executed-remaining-phases
               (symex--compute-results executed-phase
-                                      executed-remaining-phases
+                                      (if (equal executed-remaining-phases
+                                                 (list symex--move-zero))
+                                          nil
+                                          executed-remaining-phases)
                                       computation))))))))
 
 (defun symex-execute-venture (venture computation)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -260,8 +260,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
     ;; or which tests for success before moving point
     (let ((original-location (point))
           (original-point-height-offset
-           (symex-save-excursion
-            (symex--point-height-offset)))
+           (symex--point-height-offset))
           (executed-traversal (cond ((symex-maneuver-p traversal)
                                      (symex-execute-maneuver traversal
                                                              computation))
@@ -293,9 +292,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
             (progn (funcall side-effect)
                    result)
           (goto-char original-location)
-          (let* ((current-point-height-offset
-                  (symex-save-excursion
-                   (symex--point-height-offset)))
+          (let* ((current-point-height-offset (symex--point-height-offset))
                  (height-differential (- original-point-height-offset
                                          current-point-height-offset)))
             ;; necessary because point does not uniquely identify

--- a/symex-evil.el
+++ b/symex-evil.el
@@ -294,7 +294,7 @@ executing this command to get the expected behavior."
     symex-unfurl
     symex-unfurl-remaining
     symex-wrap-and-append)
-  "Commands which should have their `:repeat' property set to `t'.")
+  "Commands which should have their `:repeat' property set to t.")
 
 (defun symex-evil-initialize ()
   "Initialize evil modal interface."

--- a/symex-hydra.el
+++ b/symex-hydra.el
@@ -70,9 +70,9 @@ to enter, and any of the standard exits to exit."
 ;; likewise, we might want to disable and re-enable highlighting,
 ;; if active, on each command
 (defhydra hydra-symex (:columns 4
-                                :post (symex-hydra-exit)
-                                :after-exit (symex--signal-exit))
-  "Symex mode"
+                       :post (symex-hydra-exit)
+                       :after-exit (symex--signal-exit))
+  "Symex mode."
   ("(" symex-create-round "()")
   ("[" symex-create-square "[]")
   ("{" symex-create-curly "{}")

--- a/symex-interface-clojure.el
+++ b/symex-interface-clojure.el
@@ -30,6 +30,7 @@
 
 (declare-function cider-eval-last-sexp "ext:cider")
 (declare-function cider-eval-defun-at-point "ext:cider")
+(declare-function cider-pprint-eval-last-sexp "ext:cider")
 (declare-function cider-eval-print-last-sexp "ext:cider")
 (declare-function cider-doc "ext:cider")
 (declare-function cider-switch-to-repl-buffer "ext:cider")

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -47,6 +47,7 @@
 
 (defun symex--adjust-point ()
   "Helper to adjust point to indicate the correct symex."
+  ;; TODO: needs review for tree-sitter
   (unless (or (bobp)
               (symex--point-at-start-p)
               (save-excursion (backward-char)  ; just inside symex

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -27,7 +27,8 @@
 
 ;;; Code:
 
-(require 'symex-custom)
+(require 'symex-custom
+         'symex-primitives)
 
 ;; to avoid byte compile warnings.  eventually sort out the dependency
 ;; order so this is unnecessary
@@ -44,16 +45,6 @@
 
 (defvar-local symex--original-scroll-margin nil)
 (defvar-local symex--original-max-scroll-margin nil)
-
-(defun symex--adjust-point ()
-  "Helper to adjust point to indicate the correct symex."
-  ;; TODO: needs review for tree-sitter
-  (unless (or (bobp)
-              (symex--point-at-start-p)
-              (save-excursion (backward-char)  ; just inside symex
-                              (or (lispy-left-p)
-                                  (symex-string-p))))
-    (backward-sexp)))
 
 (defun symex--adjust-point-on-entry ()
   "Adjust point context from the Emacs to the Vim interpretation.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -369,7 +369,10 @@ difference from the lowest such level."
 
 (defun symex--point-height-offset (&optional orig-pos)
   "Compute the height offset of the current symex from the lowest one indicated by point."
-  (if tree-sitter-mode
+  (if (and tree-sitter-mode (not (symex-ts--at-root-p)))
+      ;; don't attempt to calculate offset at the "real" root
+      ;; since offsets are typically computed while ignoring it
+      ;; i.e. they are wrt. "tree root"
       (let ((orig-pos (or orig-pos (point))))
         (symex--point-height-offset-helper orig-pos))
     0))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -496,31 +496,30 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (circuit (precaution traverse
-                                  (afterwards (not (lambda ()
-                                                     (= (symex-height)
-                                                        height))))))))
-           (run-along-neighboring-branch
-            (symex-traversal
              (maneuver (decision (at first)
-                                 find-neighboring-branch
-                                 (maneuver symex--traversal-goto-first
-                                           find-neighboring-branch))
+                                 symex--move-zero
+                                 symex--traversal-goto-first)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
                        traverse
-                       symex--traversal-goto-first
-                       (circuit (precaution (move forward)
-                                            (beforehand (lambda ()
-                                                          (< (symex-index)
-                                                             index)))))))))
+                       symex--traversal-goto-first)))
+           (run-along-branch
+            (symex-traversal
+             (circuit (precaution (move forward)
+                                  (beforehand (lambda ()
+                                                (< (symex-index)
+                                                   index)))))))
+           (leap-backward
+            (symex-traversal
+             (maneuver find-neighboring-branch
+                       run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver run-along-neighboring-branch
+        (precaution (maneuver leap-backward
                               (circuit
-                               (precaution (decision (lambda ()
-                                                       (< (symex-index)
-                                                          index))
-                                                     run-along-neighboring-branch
-                                                     symex--move-zero)
+                               (precaution leap-backward
                                            (beforehand (lambda ()
                                                          (< (symex-index)
                                                             index))))))
@@ -546,30 +545,29 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (circuit (precaution traverse
-                                  (afterwards (not (lambda ()
-                                                     (= (symex-height)
-                                                        height))))))))
-           (run-along-neighboring-branch
-            (symex-traversal
              (maneuver (decision (at last)
-                                 find-neighboring-branch
-                                 (maneuver symex--traversal-goto-last
-                                           find-neighboring-branch))
-                       traverse
-                       (circuit (precaution (move forward)
-                                            (beforehand (lambda ()
-                                                          (< (symex-index)
-                                                             index)))))))))
+                                 symex--move-zero
+                                 symex--traversal-goto-last)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse)))
+           (run-along-branch
+            (symex-traversal
+             (circuit (precaution (move forward)
+                                  (beforehand (lambda ()
+                                                (< (symex-index)
+                                                   index)))))))
+           (leap-forward
+            (symex-traversal
+             (maneuver find-neighboring-branch
+                       run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver run-along-neighboring-branch
+        (precaution (maneuver leap-forward
                               (circuit
-                               (precaution (decision (lambda ()
-                                                       (< (symex-index)
-                                                          index))
-                                                     run-along-neighboring-branch
-                                                     symex--move-zero)
+                               (precaution leap-forward
                                            (beforehand (lambda ()
                                                          (< (symex-index)
                                                             index))))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -400,33 +400,9 @@ location (e.g. non-symex-based languages like Python)."
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."
   (interactive)
-  (save-excursion
-    (symex-select-nearest)
-    (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-      (length moves))))
-
-;; (defun symex-height ()  ; TODO: may be better framed as a computation
-;;   "Get height (above root) of current symex."
-;;   (interactive)
-;;   (let ((result (save-excursion
-;;                   (symex-select-nearest)
-;;                   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-;;                     (length moves)))))
-;;     (when tree-sitter-mode
-;;       (symex-ts-set-current-node-from-point)
-;;       (let ((result2 (save-excursion
-;;                        (symex-select-nearest)
-;;                        (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
-;;                          (length moves)))))
-;;         (symex-ts-set-current-node-from-point)
-;;         (symex--go-up (- result result2))))
-;;     result))
-
-(defun symex-depth ()
-  "DEPRECATED.  Renamed to `symex-height`.
-
-This interface will be removed in a future version."
-  (symex-height))
+  (symex-save-excursion
+   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+     (length moves))))
 
 (defun symex-next-visual-line (&optional count)
   "Coordinate navigation to move down.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -440,17 +440,20 @@ approach is the one employed here."
                     symex--traversal-postorder-in-tree))
         (height (symex-height))
         (index (symex-index)))
-    (let* ((find-neighboring-branch
+    (let* ((ensure-at-first-node
             (symex-traversal
-             (maneuver (decision (at first)
-                                 symex--move-zero
-                                 symex--traversal-goto-first)
+             (decision (at first)
+                       symex--move-zero
+                       symex--traversal-goto-first)))
+           (find-neighboring-branch
+            (symex-traversal
+             (maneuver ensure-at-first-node
                        (circuit (precaution traverse
                                             (afterwards (not (lambda ()
                                                                (= (symex-height)
                                                                   height))))))
                        traverse
-                       symex--traversal-goto-first)))
+                       ensure-at-first-node)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -469,7 +472,12 @@ approach is the one employed here."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))))))))
+                    (beforehand (not (at root)))
+                    (afterwards (lambda ()
+                                  (and (= (symex-index)
+                                          index)
+                                       (= (symex-height)
+                                          height))))))))))
 
 (defun symex--leap-forward (&optional soar)
   "Leap forward to a neighboring branch, preserving height and position.
@@ -512,7 +520,12 @@ the implementation."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))))))))
+                    (beforehand (not (at root)))
+                    (afterwards (lambda ()
+                                  (and (= (symex-index)
+                                          index)
+                                       (= (symex-height)
+                                          height))))))))))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -530,6 +530,10 @@ the implementation."
                                        (= (symex-height)
                                           height))))))))))
 
+(defun symex-select-nearest-advice (&rest _)
+  "Advice to select the nearest symex."
+  (symex-select-nearest))
+
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."
   (interactive)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -38,6 +38,7 @@
 (require 'symex-interface-common-lisp)
 (require 'symex-interface-arc)
 (require 'symex-interop)
+(require 'symex-ui)
 
 ;; These are customization or config variables defined elsewhere;
 ;; explicitly indicating them here to avoid byte compile warnings
@@ -533,7 +534,7 @@ the implementation."
   "Things to do as part of symex selection, e.g. after navigations."
   (interactive)
   (when symex-highlight-p
-    (mark-sexp)))
+    (symex--update-overlay)))
 
 (defun symex-selection-advice (orig-fn &rest args)
   "Attach symex selection side effects to a given function.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -353,8 +353,13 @@ Version 2017-11-01"
         result))))
 
 (defun symex--point-height-offset-helper (orig-pos)
-  "Compute the height offset of the current symex from the lowest one indicated by point."
-  (cond ((symex-ts--point-at-root-symex-p)
+  "A helper to compute the height offset of the current symex.
+
+This will always be zero for symex-oriented languages such as Lisp,
+but in languages like Python where the same point position could
+correspond to multiple hierarchy levels, this function computes the
+difference from the lowest such level."
+  (cond ((symex--point-at-root-symex-p)
          (if (= orig-pos (point))
              0
            -1))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -322,14 +322,16 @@ Version 2017-11-01"
 (defun symex-select-nearest ()
   "Select symex nearest to point."
   (interactive)
-  (cond ((and (not (eobp))
-              (save-excursion (forward-char) (lispy-right-p)))  ; |)
-         (forward-char)
-         (lispy-different))
-        ((thing-at-point 'sexp)  ; som|ething
-         (beginning-of-thing 'sexp))
-        (t (symex-if-stuck (symex--go-backward)
-                           (symex--go-forward))))
+  (if tree-sitter-mode
+      (symex-ts-set-current-node-from-point)
+    (cond ((and (not (eobp))
+                (save-excursion (forward-char) (lispy-right-p))) ; |)
+           (forward-char)
+           (lispy-different))
+          ((thing-at-point 'sexp)       ; som|ething
+           (beginning-of-thing 'sexp))
+          (t (symex-if-stuck (symex--go-backward)
+                             (symex--go-forward)))))
   (point))
 
 (defun symex-select-nearest-in-line ()

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -492,15 +492,15 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (maneuver (decision (at first)
-                                 symex--move-zero
-                                 symex--traversal-goto-first)
-                       (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
-                       traverse
-                       symex--traversal-goto-first)))
+             (venture (decision (at first)
+                                symex--move-zero
+                                symex--traversal-goto-first)
+                      (circuit (precaution traverse
+                                           (afterwards (not (lambda ()
+                                                              (= (symex-height)
+                                                                 height))))))
+                      traverse
+                      symex--traversal-goto-first)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -509,16 +509,16 @@ approach is the one employed here."
                                                    index)))))))
            (leap-backward
             (symex-traversal
-             (maneuver find-neighboring-branch
-                       run-along-branch))))
+             (venture find-neighboring-branch
+                      run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver leap-backward
-                              (circuit
-                               (precaution leap-backward
-                                           (beforehand (lambda ()
-                                                         (< (symex-index)
-                                                            index))))))
+        (precaution (venture leap-backward
+                             (circuit
+                              (precaution leap-backward
+                                          (beforehand (lambda ()
+                                                        (< (symex-index)
+                                                           index))))))
                     (beforehand (not (at root)))
                     (afterwards (lambda ()
                                   (and (= (symex-index)
@@ -541,14 +541,14 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (precaution (maneuver (decision (at last)
-                                             symex--move-zero
-                                             symex--traversal-goto-last)
-                                   (circuit (precaution traverse
-                                                        (afterwards (not (lambda ()
-                                                                           (= (symex-height)
-                                                                              height))))))
-                                   traverse)
+             (precaution (venture (decision (at last)
+                                            symex--move-zero
+                                            symex--traversal-goto-last)
+                                  (circuit (precaution traverse
+                                                       (afterwards (not (lambda ()
+                                                                          (= (symex-height)
+                                                                             height))))))
+                                  traverse)
                          (afterwards (lambda ()
                                        (= (symex-height)
                                           height))))))
@@ -560,16 +560,16 @@ the implementation."
                                                    index)))))))
            (leap-forward
             (symex-traversal
-             (maneuver find-neighboring-branch
-                       run-along-branch))))
+             (venture find-neighboring-branch
+                      run-along-branch))))
       (symex-execute-traversal
        (symex-traversal
-        (precaution (maneuver leap-forward
-                              (circuit
-                               (precaution leap-forward
-                                           (beforehand (lambda ()
-                                                         (< (symex-index)
-                                                            index))))))
+        (precaution (venture leap-forward
+                             (circuit
+                              (precaution leap-forward
+                                          (beforehand (lambda ()
+                                                        (< (symex-index)
+                                                           index))))))
                     (beforehand (not (at root)))
                     (afterwards (lambda ()
                                   (and (= (symex-index)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -324,14 +324,7 @@ Version 2017-11-01"
   (interactive)
   (if tree-sitter-mode
       (symex-ts-set-current-node-from-point)
-    (cond ((and (not (eobp))
-                (save-excursion (forward-char) (lispy-right-p))) ; |)
-           (forward-char)
-           (lispy-different))
-          ((thing-at-point 'sexp)       ; som|ething
-           (beginning-of-thing 'sexp))
-          (t (symex-if-stuck (symex--go-backward)
-                             (symex--go-forward)))))
+    (symex-lisp--select-nearest))
   (point))
 
 (defun symex-select-nearest-in-line ()
@@ -361,9 +354,10 @@ Version 2017-11-01"
 
 (defun symex--point-height-offset-helper (orig-pos)
   "Compute the height offset of the current symex from the lowest one indicated by point."
-  (cond ((symex-ts-at-root-p) (if (= orig-pos (point))
-                                  0
-                                -1))
+  (cond ((symex-ts--point-at-root-symex-p)
+         (if (= orig-pos (point))
+             0
+           -1))
         ((not (= (point) orig-pos)) -1)
         (t (symex--go-down)
            (1+ (symex--point-height-offset-helper orig-pos)))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -412,6 +412,12 @@ Leaps COUNT times, defaulting to once."
   (dotimes (_ count)
     (symex--leap-forward)))
 
+(defun symex--tree-index ()
+  "Index of current tree."
+  (symex-save-excursion
+   (symex-goto-lowest)
+   (symex-index)))
+
 (defun symex--leap-backward (&optional soar)
   "Leap backward to a neighboring branch, preserving height and position.
 
@@ -442,7 +448,8 @@ approach is the one employed here."
                       symex--traversal-postorder
                     symex--traversal-postorder-in-tree))
         (height (symex-height))
-        (index (symex-index)))
+        (index (symex-index))
+        (original-tree-index (symex--tree-index)))
     (let* ((ensure-at-first-node
             (symex-traversal
              (decision (at first)
@@ -452,9 +459,13 @@ approach is the one employed here."
             (symex-traversal
              (maneuver ensure-at-first-node
                        (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
+                                            (afterwards (lambda ()
+                                                          (or (not (= (symex-height)
+                                                                      height))
+                                                              (if soar
+                                                                  (= original-tree-index
+                                                                     (symex--tree-index))
+                                                                nil))))))
                        traverse
                        ensure-at-first-node)))
            (run-along-branch
@@ -494,16 +505,21 @@ the implementation."
                       symex--traversal-preorder
                     symex--traversal-preorder-in-tree))
         (height (symex-height))
-        (index (symex-index)))
+        (index (symex-index))
+        (original-tree-index (symex--tree-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
              (maneuver (decision (at last)
                                  symex--move-zero
                                  symex--traversal-goto-last)
                        (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
+                                            (afterwards (lambda ()
+                                                          (or (not (= (symex-height)
+                                                                      height))
+                                                              (if soar
+                                                                  (= original-tree-index
+                                                                     (symex--tree-index))
+                                                                nil))))))
                        traverse)))
            (run-along-branch
             (symex-traversal

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -541,14 +541,17 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (maneuver (decision (at last)
-                                 symex--move-zero
-                                 symex--traversal-goto-last)
-                       (circuit (precaution traverse
-                                            (afterwards (not (lambda ()
-                                                               (= (symex-height)
-                                                                  height))))))
-                       traverse)))
+             (precaution (maneuver (decision (at last)
+                                             symex--move-zero
+                                             symex--traversal-goto-last)
+                                   (circuit (precaution traverse
+                                                        (afterwards (not (lambda ()
+                                                                           (= (symex-height)
+                                                                              height))))))
+                                   traverse)
+                         (afterwards (lambda ()
+                                       (= (symex-height)
+                                          height))))))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -38,8 +38,6 @@
 (require 'symex-interface-common-lisp)
 (require 'symex-interface-arc)
 (require 'symex-interop)
-(require 'tree-sitter)
-(require 'symex-ts)
 
 ;; These are customization or config variables defined elsewhere;
 ;; explicitly indicating them here to avoid byte compile warnings
@@ -648,10 +646,9 @@ ORIG-FN applied to ARGS is the invocation being advised."
   (unless (member evil-next-state '(emacslike normallike))
     ;; these are "internal" state transitions, used in e.g. symex-evaluate
     (deactivate-mark)
-    (when tree-sitter-mode
-      (symex-ts--delete-overlay))
     (when symex-refocus-p
-      (symex--restore-scroll-margin))))
+      (symex--restore-scroll-margin))
+    (symex--primitive-exit)))
 
 (provide 'symex-misc)
 ;;; symex-misc.el ends here

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -532,7 +532,8 @@ the implementation."
 
 (defun symex-select-nearest-advice (&rest _)
   "Advice to select the nearest symex."
-  (symex-select-nearest))
+  (when (evil-symex-state-p)
+    (symex-select-nearest)))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -46,6 +46,7 @@
 (defvar symex-highlight-p)
 (defvar symex-racket-modes)
 (defvar symex-elisp-modes)
+(defvar symex-clojure-modes)
 
 ;; buffer-local branch memory stack
 (defvar-local symex--branch-memory nil)
@@ -548,7 +549,8 @@ the implementation."
 
 (defun symex-select-nearest-advice (&rest _)
   "Advice to select the nearest symex."
-  (when (evil-symex-state-p)
+  (when (and (fboundp 'evil-symex-state-p)
+             (evil-symex-state-p))
     (symex-select-nearest)))
 
 (defun symex--selection-side-effects ()

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -349,7 +349,7 @@ Version 2017-11-01"
 (defun symex-index ()  ; TODO: may be better framed as a computation
   "Get relative (from start of containing symex) index of current symex."
   (interactive)
-  (save-excursion
+  (symex-save-excursion
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
             (result 0))
@@ -382,19 +382,21 @@ Like `save-excursion`, but in addition to preserving the point
 position, this also preserves the structural position in the tree, for
 languages where point position doesn't uniquely identify a tree
 location (e.g. non-symex-based languages like Python)."
-  `(let ((offset 0))
-      (when tree-sitter-mode
-        (setq offset (save-excursion
-                       (symex--point-height-offset)))
-        (symex-select-nearest)
-        (symex--go-up offset))
-      (let ((result
-             (save-excursion
-               ,@body)))
-        (when tree-sitter-mode
-          (symex-select-nearest)
-          (symex--go-up offset))
-        result)))
+  (let ((offset (gensym))
+        (result (gensym)))
+    `(let ((,offset 0))
+       (when tree-sitter-mode
+         (setq ,offset (save-excursion
+                         (symex--point-height-offset)))
+         (symex-select-nearest)
+         (symex--go-up ,offset))
+       (let ((,result
+              (save-excursion
+                ,@body)))
+         (when tree-sitter-mode
+           (symex-select-nearest)
+           (symex--go-up ,offset))
+         ,result))))
 
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -350,7 +350,6 @@ Version 2017-11-01"
   "Get relative (from start of containing symex) index of current symex."
   (interactive)
   (save-excursion
-    (symex-select-nearest)
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
             (result 0))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -335,9 +335,11 @@ Version 2017-11-01"
   (symex-save-excursion
     (let ((original-location (point)))
       (let ((current-location (symex-goto-first))
+            (move-made symex--move-zero)
             (result 0))
-        (while (< current-location original-location)
-          (symex--execute-tree-move (symex-make-move 1 0))
+        (while (and move-made
+                    (< current-location original-location))
+          (setq move-made (symex--execute-tree-move (symex-make-move 1 0)))
           (setq current-location (point))
           (setq result (1+ result)))
         result))))

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -366,6 +366,23 @@ Version 2017-11-01"
     (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
       (length moves))))
 
+;; (defun symex-height ()  ; TODO: may be better framed as a computation
+;;   "Get height (above root) of current symex."
+;;   (interactive)
+;;   (let ((result (save-excursion
+;;                   (symex-select-nearest)
+;;                   (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+;;                     (length moves)))))
+;;     (when tree-sitter-mode
+;;       (symex-ts-set-current-node-from-point)
+;;       (let ((result2 (save-excursion
+;;                        (symex-select-nearest)
+;;                        (let ((moves (symex-execute-traversal symex--traversal-goto-lowest)))
+;;                          (length moves)))))
+;;         (symex-ts-set-current-node-from-point)
+;;         (symex--go-up (- result result2))))
+;;     result))
+
 (defun symex-depth ()
   "DEPRECATED.  Renamed to `symex-height`.
 

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -28,7 +28,7 @@
 
 (require 'lispy)
 (require 'evil)
-(require 'symex-primitives-lisp)
+(require 'symex-primitives)
 (require 'symex-evaluator)
 (require 'symex-traversals)
 (require 'symex-interface-elisp)
@@ -319,14 +319,6 @@ Version 2017-11-01"
   (recenter)
   (evil-window-mru))
 
-(defun symex-select-nearest ()
-  "Select symex nearest to point."
-  (interactive)
-  (if tree-sitter-mode
-      (symex-ts-set-current-node-from-point)
-    (symex-lisp--select-nearest))
-  (point))
-
 (defun symex-select-nearest-in-line ()
   "Select symex nearest to point that's on the current line."
   (interactive)
@@ -351,54 +343,6 @@ Version 2017-11-01"
           (setq current-location (point))
           (setq result (1+ result)))
         result))))
-
-(defun symex--point-height-offset-helper (orig-pos)
-  "A helper to compute the height offset of the current symex.
-
-This will always be zero for symex-oriented languages such as Lisp,
-but in languages like Python where the same point position could
-correspond to multiple hierarchy levels, this function computes the
-difference from the lowest such level."
-  (cond ((symex--point-at-root-symex-p)
-         (if (= orig-pos (point))
-             0
-           -1))
-        ((not (= (point) orig-pos)) -1)
-        (t (symex--go-down)
-           (1+ (symex--point-height-offset-helper orig-pos)))))
-
-(defun symex--point-height-offset (&optional orig-pos)
-  "Compute the height offset of the current symex from the lowest one indicated by point."
-  (if (and tree-sitter-mode (not (symex-ts--at-root-p)))
-      ;; don't attempt to calculate offset at the "real" root
-      ;; since offsets are typically computed while ignoring it
-      ;; i.e. they are wrt. "tree root"
-      (let ((orig-pos (or orig-pos (point))))
-        (symex--point-height-offset-helper orig-pos))
-    0))
-
-(defmacro symex-save-excursion (&rest body)
-  "Execute BODY while preserving position in the tree.
-
-Like `save-excursion`, but in addition to preserving the point
-position, this also preserves the structural position in the tree, for
-languages where point position doesn't uniquely identify a tree
-location (e.g. non-symex-based languages like Python)."
-  (let ((offset (gensym))
-        (result (gensym)))
-    `(let ((,offset 0))
-       (when tree-sitter-mode
-         (setq ,offset (save-excursion
-                         (symex--point-height-offset)))
-         (symex-select-nearest)
-         (symex--go-up ,offset))
-       (let ((,result
-              (save-excursion
-                ,@body)))
-         (when tree-sitter-mode
-           (symex-select-nearest)
-           (symex--go-up ,offset))
-         ,result))))
 
 (defun symex-height ()  ; TODO: may be better framed as a computation
   "Get height (above root) of current symex."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -492,15 +492,15 @@ approach is the one employed here."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (venture (decision (at first)
-                                symex--move-zero
-                                symex--traversal-goto-first)
-                      (circuit (precaution traverse
-                                           (afterwards (not (lambda ()
-                                                              (= (symex-height)
-                                                                 height))))))
-                      traverse
-                      symex--traversal-goto-first)))
+             (maneuver (decision (at first)
+                                 symex--move-zero
+                                 symex--traversal-goto-first)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse
+                       symex--traversal-goto-first)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -519,12 +519,7 @@ approach is the one employed here."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))
-                    (afterwards (lambda ()
-                                  (and (= (symex-index)
-                                          index)
-                                       (= (symex-height)
-                                          height))))))))))
+                    (beforehand (not (at root)))))))))
 
 (defun symex--leap-forward (&optional soar)
   "Leap forward to a neighboring branch, preserving height and position.
@@ -541,17 +536,14 @@ the implementation."
         (index (symex-index)))
     (let* ((find-neighboring-branch
             (symex-traversal
-             (precaution (venture (decision (at last)
-                                            symex--move-zero
-                                            symex--traversal-goto-last)
-                                  (circuit (precaution traverse
-                                                       (afterwards (not (lambda ()
-                                                                          (= (symex-height)
-                                                                             height))))))
-                                  traverse)
-                         (afterwards (lambda ()
-                                       (= (symex-height)
-                                          height))))))
+             (maneuver (decision (at last)
+                                 symex--move-zero
+                                 symex--traversal-goto-last)
+                       (circuit (precaution traverse
+                                            (afterwards (not (lambda ()
+                                                               (= (symex-height)
+                                                                  height))))))
+                       traverse)))
            (run-along-branch
             (symex-traversal
              (circuit (precaution (move forward)
@@ -570,12 +562,7 @@ the implementation."
                                           (beforehand (lambda ()
                                                         (< (symex-index)
                                                            index))))))
-                    (beforehand (not (at root)))
-                    (afterwards (lambda ()
-                                  (and (= (symex-index)
-                                          index)
-                                       (= (symex-height)
-                                          height))))))))))
+                    (beforehand (not (at root)))))))))
 
 (defun symex--selection-side-effects ()
   "Things to do as part of symex selection, e.g. after navigations."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -266,7 +266,8 @@ as special cases here."
         (t (symex-lisp--if-stuck (symex-lisp--backward)
                                  (symex-lisp--forward)))))
 
-(defun symex--get-starting-point ()
+
+(defun symex-lisp--get-starting-point ()
   "Get the point value at the start of the current symex."
   (save-excursion
     (unless (symex--point-at-start-p)
@@ -275,18 +276,27 @@ as special cases here."
         (error nil)))
     (point)))
 
-(defun symex--get-end-point (count)
+(defun symex-lisp--get-end-point-helper (count)
+  "Helper to get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found.
+
+Note that this mutates point - it should not be called directly."
+  (if (= count 0)
+      (point)
+    (condition-case nil
+        (forward-sexp)
+      (error (point)))
+    (symex-lisp--get-end-point-helper (1- count))))
+
+(defun symex-lisp--get-end-point (count)
   "Get the point value after COUNT symexes.
 
 If the containing expression terminates earlier than COUNT
 symexes, returns the end point of the last one found."
   (save-excursion
-    (if (= count 0)
-        (point)
-      (condition-case nil
-          (forward-sexp)
-        (error (point)))
-      (symex--get-end-point (1- count)))))
+    (symex-lisp--get-end-point-helper count)))
 
 (defun symex-lisp--forward-one ()
   "Forward one symex."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -85,7 +85,7 @@
         (or (bobp)
             (progn (backward-sexp 1)
                    (not (thing-at-point 'sexp))))
-      (error nil)))))
+      (error nil))))
 
 (defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -299,10 +299,10 @@ symexes, returns the end point of the last one found."
     (symex-lisp--get-end-point-helper count)))
 
 (defun symex-lisp--point-height-offset ()
-  "Compute the height offset of the current symex from the lowest one
-indicated by point.
+  "Compute the height offset of the current symex.
 
-For symex-oriented languages like Lisp, this is always zero."
+This is measured from the lowest symex indicated by point. For
+symex-oriented languages like Lisp, this is always zero."
   0)
 
 (defun symex-lisp--forward-one ()

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -40,54 +40,47 @@
 
 ;;; Predicates
 
-(defmacro symex-if-stuck (do-what operation &rest body)
+(defmacro symex-lisp--if-stuck (do-what operation &rest body)
   "Attempt OPERATION and if it fails, then do DO-WHAT."
-  `(let ((orig-pt (point)))
-     ,operation
-     (if (= orig-pt (point))
-         ,do-what
-       ,@body)))
+  (let ((orig-pt (gensym)))
+    `(let ((,orig-pt (point)))
+       ,operation
+       (if (= ,orig-pt (point))
+           ,do-what
+         ,@body))))
 
-(defun symex--point-at-root-symex-p ()
+(defun symex-lisp--point-at-root-symex-p ()
   "Check if point is at a root symex."
   (save-excursion
-    (symex-if-stuck t
-                    (symex-lisp--exit)
-                    nil)))
+    (symex-lisp--if-stuck t
+                          (symex-lisp--exit)
+                          nil)))
 
-(defun symex--point-at-first-symex-p ()
+(defun symex-lisp--point-at-first-symex-p ()
   "Check if point is at the first symex at some level."
   (save-excursion
-    (symex-if-stuck t
-                    (symex-lisp--backward)
-                    nil)))
+    (symex-lisp--if-stuck t
+                          (symex-lisp--backward)
+                          nil)))
 
-(defun symex--point-at-last-symex-p ()
+(defun symex-lisp--point-at-last-symex-p ()
   "Check if point is at the last symex at some level."
   (save-excursion
-    (symex-if-stuck t
-                    (symex-lisp--forward)
-                    nil)))
+    (symex-lisp--if-stuck t
+                          (symex-lisp--forward)
+                          nil)))
 
-(defun symex--point-at-final-symex-p ()
+(defun symex-lisp--point-at-final-symex-p ()
   "Check if point is at the last symex in the buffer."
-  (save-excursion
-    (symex-if-stuck (progn (symex-if-stuck t
-                                           (symex-lisp--exit)
-                                           nil))
-                    (symex-lisp--forward)
-                    nil)))
+  (and (symex-lisp--point-at-last-symex-p)
+       (symex-lisp--point-at-root-symex-p)))
 
-(defun symex--point-at-initial-symex-p ()
+(defun symex-lisp--point-at-initial-symex-p ()
   "Check if point is at the first symex in the buffer."
-  (save-excursion
-    (condition-case nil
-        (or (bobp)
-            (progn (backward-sexp 1)
-                   (not (thing-at-point 'sexp))))
-      (error nil))))
+  (and (symex-lisp--point-at-first-symex-p)
+       (symex-lisp--point-at-root-symex-p)))
 
-(defun symex--point-at-start-p ()
+(defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."
   (and (not (eolp))
        (not (looking-at-p lispy-right))
@@ -242,6 +235,17 @@ as special cases here."
                               (point))))))))
 
 ;;; Navigation
+
+(defun symex-lisp--select-nearest ()
+  "Select the appropriate symex nearest to point."
+  (cond ((and (not (eobp))
+              (save-excursion (forward-char) (lispy-right-p))) ; |)
+         (forward-char)
+         (lispy-different))
+        ((thing-at-point 'sexp)       ; som|ething
+         (beginning-of-thing 'sexp))
+        (t (symex-lisp--if-stuck (symex--go-backward)
+                                 (symex--go-forward)))))
 
 (defun symex--get-starting-point ()
   "Get the point value at the start of the current symex."

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -77,8 +77,15 @@
 
 (defun symex-lisp--point-at-initial-symex-p ()
   "Check if point is at the first symex in the buffer."
-  (and (symex-lisp--point-at-first-symex-p)
-       (symex-lisp--point-at-root-symex-p)))
+  ;; this is used in the primitive motions, so it cannot
+  ;; be defined in terms of them, as the other predicates
+  ;; above are
+  (save-excursion
+    (condition-case nil
+        (or (bobp)
+            (progn (backward-sexp 1)
+                   (not (thing-at-point 'sexp))))
+      (error nil)))))
 
 (defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."
@@ -326,7 +333,7 @@ of symex mode (use the public `symex-go-forward` instead)."
 (defun symex-lisp--backward-one ()
   "Backward one symex."
   (let ((result 0))
-    (unless (symex--point-at-initial-symex-p)
+    (unless (symex-lisp--point-at-initial-symex-p)
       (condition-case nil
           (progn (backward-sexp 1)
                  (setq result (1+ result)))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -298,6 +298,13 @@ symexes, returns the end point of the last one found."
   (save-excursion
     (symex-lisp--get-end-point-helper count)))
 
+(defun symex-lisp--point-height-offset ()
+  "Compute the height offset of the current symex from the lowest one
+indicated by point.
+
+For symex-oriented languages like Lisp, this is always zero."
+  0)
+
 (defun symex-lisp--forward-one ()
   "Forward one symex."
   (let ((original-location (point))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -38,6 +38,18 @@
 ;;; PRIMITIVES ;;;
 ;;;;;;;;;;;;;;;;;;
 
+;;; User Interface
+
+(defun symex-lisp--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  (unless (or (bobp)
+              (symex-lisp--point-at-start-p)
+              (looking-back "," (line-beginning-position))
+              (save-excursion (backward-char)  ; just inside symex
+                              (or (lispy-left-p)
+                                  (symex-string-p))))
+    (backward-sexp)))
+
 ;;; Predicates
 
 (defmacro symex-lisp--if-stuck (do-what operation &rest body)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -44,7 +44,7 @@
   "Helper to adjust point to indicate the correct symex."
   (unless (or (bobp)
               (symex-lisp--point-at-start-p)
-              (looking-back "," (line-beginning-position))
+              (looking-back "[,'`]" (line-beginning-position))
               (save-excursion (backward-char)  ; just inside symex
                               (or (lispy-left-p)
                                   (symex-string-p))))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -199,6 +199,21 @@ location (e.g. non-symex-based languages like Python)."
          (symex--go-up ,offset)
          ,result))))
 
+(defun symex--get-starting-point ()
+  "Get the point value at the start of the current symex."
+  (if tree-sitter-mode
+      (symex-ts--get-starting-point)
+    (symex-lisp--get-starting-point)))
+
+(defun symex--get-end-point (count)
+  "Get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found."
+  (if tree-sitter-mode
+      (symex-ts--get-end-point count)
+    (symex-lisp--get-end-point count)))
+
 (defun symex-select-nearest ()
   "Select symex nearest to point."
   (interactive)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -150,13 +150,21 @@ difference from the lowest such level."
   "Compute the height offset of the current symex from the lowest one
 indicated by point."
   (if tree-sitter-mode
+      ;; don't attempt to calculate offset at the "real" root
+      ;; since offsets are typically computed while ignoring it
+      ;; i.e. they are wrt. "tree root"
       (cond ((symex-ts--at-root-p) 0)
+            ;; at the "tree root" of the first symex in the buffer,
+            ;; point-height offset must account for "true" root
+            ;; and so it's 1 rather than 0 here
             ((symex-ts--at-initial-p) 1)
-            ;; don't attempt to calculate offset at the "real" root
-            ;; since offsets are typically computed while ignoring it
-            ;; i.e. they are wrt. "tree root"
+            ;; aside from the above special cases, compute point-height
+            ;; offset by just descending as long as point does not change,
+            ;; and counting the number of steps taken
             (t (let* ((orig-pos (point))
                       (offset (symex--point-height-offset-helper orig-pos)))
+                 ;; return to original tree position
+                 ;; before returning the result
                  (goto-char orig-pos)
                  (symex-select-nearest)
                  (symex--go-up offset)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -157,8 +157,9 @@ location (e.g. non-symex-based languages like Python)."
          ,result))))
 
 (defun symex--point-height-offset ()
-  "Compute the height offset of the current symex from the lowest one
-indicated by point.
+  "Compute the height offset of the current symex.
+
+This is measured from the lowest symex indicated by point.
 
 This will always be zero for symex-oriented languages such as Lisp,
 but in languages like Python where the same point position could
@@ -192,8 +193,7 @@ symexes, returns the end point of the last one found."
   (point))
 
 (defun symex--primitive-exit ()
-  "Take any necessary actions as part of exiting Symex mode, at a
-primitive level."
+  "Take necessary actions as part of exiting Symex mode, at a primitive level."
   (symex--delete-overlay)
   (if tree-sitter-mode
       (symex-ts--exit)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -149,6 +149,9 @@ difference from the lowest such level."
 (defun symex--point-height-offset ()
   "Compute the height offset of the current symex from the lowest one
 indicated by point."
+  ;; TODO: probably make this a tree-sitter utility instead, so that
+  ;; it uses tree-sitter APIs to determine point-height offset instead
+  ;; of doing it at the level of traversals.
   (if tree-sitter-mode
       ;; don't attempt to calculate offset at the "real" root
       ;; since offsets are typically computed while ignoring it

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -225,6 +225,7 @@ symexes, returns the end point of the last one found."
 (defun symex--primitive-exit ()
   "Take any necessary actions as part of exiting Symex mode, at a
 primitive level."
+  (symex--delete-overlay)
   (if tree-sitter-mode
       (symex-ts--exit)
     (symex-lisp--exit)))

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -33,6 +33,14 @@
 (require 'symex-primitives-lisp)
 (require 'symex-ts)
 
+;;; User Interface
+
+(defun symex--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  (if tree-sitter-mode
+      (symex-ts--adjust-point)
+    (symex-lisp--adjust-point)))
+
 ;;; Predicates
 
 (defun symex--point-at-root-symex-p ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -33,6 +33,50 @@
 (require 'symex-primitives-lisp)
 (require 'symex-ts)
 
+;;; Predicates
+
+(defun symex--point-at-root-symex-p ()
+  "Check if point is at a root symex."
+  (if tree-sitter-mode
+      ;; note that tree-sitter has a global
+      ;; root for the whole file -- that's
+      ;; not the one we mean here, but
+      ;; rather, top level definitions
+      (symex-ts--at-tree-root-p)
+    (symex-lisp--point-at-root-symex-p)))
+
+(defun symex--point-at-first-symex-p ()
+  "Check if point is at the first symex at some level."
+  (if tree-sitter-mode
+      (symex-ts--at-first-p)
+    (symex-lisp--point-at-first-symex-p)))
+
+(defun symex--point-at-last-symex-p ()
+  "Check if point is at the last symex at some level."
+  (if tree-sitter-mode
+      (symex-ts--at-last-p)
+    (symex-lisp--point-at-last-symex-p)))
+
+(defun symex--point-at-final-symex-p ()
+  "Check if point is at the last symex in the buffer."
+  (if tree-sitter-mode
+      (symex-ts--at-final-p)
+    (symex-lisp--point-at-final-symex-p)))
+
+(defun symex--point-at-initial-symex-p ()
+  "Check if point is at the first symex in the buffer."
+  (if tree-sitter-mode
+      (symex-ts--at-initial-p)
+    (symex-lisp--point-at-initial-symex-p)))
+
+(defun symex--point-at-start-p ()
+  "Check if point is at the start of a symex."
+  (if tree-sitter-mode
+      (symex-ts--point-at-start-p)
+    (symex-lisp--point-at-start-p)))
+
+;;; Navigation
+
 (defun symex--forward (&optional count)
   "Forward symex.
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -97,5 +97,57 @@
     (kill-region start end))
   (symex-enter-lowest))
 
+(defun symex-lisp--append-after ()
+  "Append after symex (instead of vim's default of line)."
+  (interactive)
+  (forward-sexp)  ; selected symexes will have the cursor on the starting paren
+  (insert " ")
+  (symex-enter-lowest))
+
+(defun symex-lisp--open-line-after ()
+  "Open new line after symex."
+  (interactive)
+  (forward-sexp)
+  (newline-and-indent)
+  (symex-enter-lowest))
+
+(defun symex-lisp--open-line-before ()
+  "Open new line before symex."
+  (interactive)
+  (newline-and-indent)
+  (evil-previous-line)
+  (indent-according-to-mode)
+  (evil-move-end-of-line)
+  (unless (or (symex--current-line-empty-p)
+              (save-excursion (backward-char)
+                              (lispy-left-p)))
+    (insert " "))
+  (symex-enter-lowest))
+
+(defun symex-lisp--insert-before ()
+  "Insert before symex (instead of vim's default at the start of line)."
+  (interactive)
+  (insert " ")
+  (backward-char)
+  (symex-enter-lowest))
+
+(defun symex-lisp--insert-at-beginning ()
+  "Insert at beginning of symex."
+  (interactive)
+  (when (or (lispy-left-p)
+            (symex-string-p))
+    (forward-char))
+  (symex-enter-lowest))
+
+(defun symex-lisp--insert-at-end ()
+  "Insert at end of symex."
+  (interactive)
+  (if (or (lispy-left-p)
+          (symex-string-p))
+      (progn (forward-sexp)
+             (backward-char))
+    (forward-sexp))
+  (symex-enter-lowest))
+
 (provide 'symex-transformations-lisp)
 ;;; symex-transformations-lisp.el ends here

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 
-;; Standard mutative operations to be performed on symexes.
+;; Standard mutative operations to be performed on Lisp symexes.
 
 ;;; Code:
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -149,5 +149,53 @@
     (forward-sexp))
   (symex-enter-lowest))
 
+(defun symex-lisp--paste-after ()
+  "Paste after symex."
+  (interactive)
+  (let ((extra-to-prepend
+         (cond ((or (and (symex--point-at-indentation-p)
+                         (not (bolp)))
+                    (save-excursion (forward-sexp)
+                                    (eolp)))
+                "\n")
+               (t " "))))
+    (save-excursion
+      (forward-sexp)
+      (insert extra-to-prepend)
+      (evil-paste-before nil nil))
+    (symex--go-forward)
+    (symex-tidy)))
+
+(defun symex-lisp--paste-before ()
+  "Paste before symex."
+  (interactive)
+  (let ((extra-to-append
+         (cond ((or (and (symex--point-at-indentation-p)
+                         (not (bolp)))
+                    (save-excursion (forward-sexp)
+                                    (eolp)))
+                "\n")
+               (t " "))))
+    (save-excursion
+      (save-excursion
+        (evil-paste-before nil nil)
+        (when evil-move-cursor-back
+          (forward-char))
+        (insert extra-to-append))
+      (symex--go-forward)
+      (symex-tidy))
+    (symex-tidy)))
+
+(defun symex-lisp--yank (count)
+  "Yank (copy) COUNT symexes."
+  (interactive "p")
+  ;; we set `last-command` here to avoid appending to the kill ring
+  ;; when it's a delete followed by a yank. We want to treat each as
+  ;; independent entries in the kill ring
+  (let ((last-command nil))
+    (let ((start (point))
+          (end (symex--get-end-point count)))
+      (copy-region-as-kill start end))))
+
 (provide 'symex-transformations-lisp)
 ;;; symex-transformations-lisp.el ends here

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -1,0 +1,101 @@
+;;; symex-transformations-lisp.el --- An evil way to edit Lisp symbolic expressions as trees -*- lexical-binding: t -*-
+
+;; URL: https://github.com/countvajhula/symex.el
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; Standard mutative operations to be performed on symexes.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(require 'paredit)
+(require 'lispy)
+(require 'evil)
+(require 'evil-surround)
+(require 'evil-cleverparens)  ;; really only need cp-textobjects here
+(require 'symex-primitives)
+(require 'symex-primitives-lisp)
+(require 'symex-utils)
+(require 'symex-traversals)
+(require 'symex-interop)
+
+;;;;;;;;;;;;;;;;;;;;;;;
+;;; TRANSFORMATIONS ;;;
+;;;;;;;;;;;;;;;;;;;;;;;
+
+(defun symex-lisp--delete (count)
+  "Delete COUNT symexes."
+  (interactive "p")
+  (let ((last-command nil)  ; see symex-yank re: last-command
+        (start (point))
+        (end (symex--get-end-point count)))
+    (kill-region start end))
+  (cond ((or (symex--current-line-empty-p)         ; ^<>$
+             (save-excursion (evil-last-non-blank) ; (<>$
+                             (lispy-left-p))
+             (looking-at-p "\n")) ; (abc <>
+         (symex--join-to-next))
+        ((save-excursion (back-to-indentation) ; ^<>)
+                         (forward-char)
+                         (lispy-right-p))
+         ;; Cases 2 and 3 in issue #18
+         ;; if the deleted symex is preceded by a comment line
+         ;; or if the preceding symex is followed by a comment
+         ;; on the same line, then don't attempt to join lines
+         (let ((original-position (point)))
+           (when (symex--go-backward)
+             (let ((previous-symex-end-pos (symex--get-end-point 1)))
+               (unless (symex--intervening-comment-line-p previous-symex-end-pos
+                                                          original-position)
+                 (goto-char previous-symex-end-pos)
+                 ;; ensure that there isn't a comment on the
+                 ;; preceding line before joining lines
+                 (unless (condition-case nil
+                             (progn (evil-find-char 1 ?\;)
+                                    t)
+                           (error nil))
+                   (symex--join-to-match lispy-right)
+                   (symex--adjust-point)))))))
+        ((save-excursion (forward-char) ; ... <>)
+                         (lispy-right-p))
+         (symex--go-backward))
+        (t (symex--go-forward)))
+  (symex-select-nearest)
+  (symex-tidy))
+
+(defun symex-lisp--delete-backwards (count)
+  "Delete COUNT symexes backwards."
+  (interactive "p")
+  (dotimes (_ count)
+    (when (symex--go-backward)
+      (symex-delete 1))))
+
+(defun symex-lisp--change (count)
+  "Change COUNT symexes."
+  (interactive "p")
+  (let ((start (point))
+        (end (symex--get-end-point count)))
+    (kill-region start end))
+  (symex-enter-lowest))
+
+(provide 'symex-transformations-lisp)
+;;; symex-transformations-lisp.el ends here

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -1,0 +1,98 @@
+;;; symex-transformations-ts.el --- An evil way to edit Lisp symbolic expressions as trees -*- lexical-binding: t -*-
+
+;; URL: https://github.com/countvajhula/symex.el
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; Standard mutative operations to be performed on symexes via Tree
+;; Sitter.
+
+;;; Code:
+
+(require 'tree-sitter)
+
+(defun symex-ts-delete-node-backward (&optional count)
+  "Delete COUNT nodes backward from the current node."
+  (interactive "p")
+  (let* ((count (or count 1))
+         (node (tsc-get-prev-named-sibling (symex-ts-get-current-node))))
+    (when node
+      (let ((end-pos (tsc-node-end-position node))
+            (start-pos (tsc-node-start-position
+                        (if (> count 1)
+                            (symex-ts--get-nth-sibling-from-node node #'tsc-get-prev-named-sibling count)
+                          node))))
+        (kill-region start-pos end-pos)
+        (symex-ts--delete-current-line-if-empty start-pos)
+        (symex-ts-set-current-node-from-point)))))
+
+(defun symex-ts-delete-node-forward (&optional count keep-empty-lines)
+  "Delete COUNT nodes forward from the current node.
+
+If KEEP-EMPTY-LINES is set then if the deletion results in an
+empty line it will be kept. By default empty lines are deleted
+too."
+  (interactive "p")
+  (let* ((count (or count 1))
+         (node (symex-ts-get-current-node))
+         (next-node (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count))
+         (start-pos (tsc-node-start-position node))
+         (end-pos (tsc-node-end-position
+                   (if (> count 1)
+                       (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count)
+                     node))))
+
+    (if next-node
+        (symex-ts--set-current-node next-node)
+      (symex-ts-set-current-node-from-point))
+    (kill-region start-pos end-pos)
+
+    (when (not keep-empty-lines) (symex-ts--delete-current-line-if-empty start-pos))
+    (symex-ts-set-current-node-from-point)))
+
+(defun symex-ts-change-node-forward (&optional count)
+  "Delete COUNT nodes forward from the current node and enter Insert state."
+  (interactive "p")
+  (save-excursion (symex-ts-delete-node-forward count t))
+  (evil-insert-state 1))
+
+;; TODO: TS: append after node
+;; TODO: TS: capture node
+;; TODO: TS: clear node
+;; TODO: TS: comment node
+;; TODO: TS: delete remaining nodes
+;; TODO: TS: emit node
+;; TODO: TS: insert at beginning/end of node
+;; TODO: TS: insert before node
+;; TODO: TS: open line before/after node
+;; TODO: TS: paste node
+;; TODO: TS: replace node
+;; TODO: TS: shift forward/backward node
+;; TODO: TS: splice node
+;; TODO: TS: swallow node
+;; TODO: TS: wrap node
+;; TODO: TS: yank node
+
+;; TODO: TS: join node ?
+;; TODO: TS: split node ?
+
+
+(provide 'symex-transformations-ts)
+;;; symex-transformations-ts.el ends here

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -93,22 +93,24 @@ If KEEP-EMPTY-LINES is set then if the deletion results in an
 empty line it will be kept. By default empty lines are deleted
 too."
   (interactive "p")
-  (let* ((count (or count 1))
-         (node (symex-ts-get-current-node))
-         (next-node (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count))
-         (start-pos (tsc-node-start-position node))
-         (end-pos (tsc-node-end-position
-                   (if (> count 1)
-                       (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count)
-                     node))))
+  (symex-ts--handle-tree-modification
+   (let* ((count (or count 1))
+          (node (symex-ts-get-current-node))
+          (start-pos (tsc-node-start-position node))
+          (end-pos (tsc-node-end-position
+                    (if (> count 1)
+                        (symex-ts--get-nth-sibling-from-node
+                         node
+                         #'tsc-get-next-named-sibling count)
+                      node))))
 
-    (if next-node
-        (symex-ts--set-current-node next-node)
-      (symex-ts-set-current-node-from-point))
-    (kill-region start-pos end-pos)
+     ;; Delete the node's region
+     (kill-region start-pos end-pos)
 
-    (when (not keep-empty-lines) (symex-ts--delete-current-line-if-empty start-pos))
-    (symex-ts-set-current-node-from-point)))
+     ;; Remove all empty lines following the deletion
+     (when (not keep-empty-lines)
+       (let ((cont t))
+         (while cont (setq cont (symex-ts--delete-current-line-if-empty start-pos))))))))
 
 (defun symex-ts-insert-at-beginning ()
   "Insert at beginning of symex."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -71,6 +71,20 @@ selected according to the ranges that have changed."
   (save-excursion (symex-ts-delete-node-forward count t))
   (evil-insert-state 1))
 
+(defun symex-ts-clear ()
+  "Clear contents of symex."
+  (when symex-ts--current-node
+    (let ((child-count (tsc-count-named-children symex-ts--current-node)))
+
+      ;; If the node has children, delete them. Otherwise, just delete
+      ;; the current node using `symex-ts-delete-node-forward'.
+      (if (> child-count 0)
+        (let ((first-child (tsc-get-nth-named-child symex-ts--current-node 0))
+              (last-child (tsc-get-nth-named-child symex-ts--current-node (1- child-count))))
+          (when (and first-child last-child)
+            (kill-region (tsc-node-start-position first-child) (tsc-node-end-position last-child))))
+        (symex-ts-delete-node-forward 1 t)))))
+
 (defun symex-ts-delete-node-backward (&optional count)
   "Delete COUNT nodes backward from the current node."
   (interactive "p")
@@ -201,7 +215,6 @@ DIRECTION should be either the symbol `before' or `after'."
 
 
 ;; TODO: TS: capture node
-;; TODO: TS: clear node
 ;; TODO: TS: comment node
 ;; TODO: TS: delete remaining nodes
 ;; TODO: TS: emit node

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -41,7 +41,7 @@ selected according to the ranges that have changed."
     `(let ((,prev-tree tree-sitter-tree))
 
        ;; Execute BODY, bind to RES
-       (let ((,res ,@body))
+       (let ((,res (progn ,@body)))
 
          ;; Get changes from previous to current tree
          (let ((,changed-ranges (tsc-changed-ranges ,prev-tree tree-sitter-tree)))

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -121,19 +121,55 @@ too."
     (indent-according-to-mode)
     (evil-append-line 1)))
 
+(defun symex-ts-paste-after (count)
+  "Paste after symex, COUNT times."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (let* ((node (symex-ts-get-current-node))
+           (end (tsc-node-end-position node)))
+      (goto-char end)
+      (dotimes (_ count) (yank))
+      (forward-char -1)
+      (symex-ts-set-current-node-from-point))))
+
+(defun symex-ts-paste-before (count)
+  "Paste before symex, COUNT times."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (let* ((node (symex-ts-get-current-node))
+           (start (tsc-node-start-position node)))
+      (goto-char start)
+      (evil-paste-before count)
+      (symex-ts-set-current-node-from-point))))
+
+(defun symex-ts-yank (count)
+  "Yank (copy) COUNT symexes."
+  (interactive "p")
+  ;; we set `last-command` here to avoid appending to the kill ring
+  ;; when it's a delete followed by a yank. We want to treat each as
+  ;; independent entries in the kill ring
+  (when (symex-ts-get-current-node)
+    (let* ((last-command nil)
+           (node (symex-ts-get-current-node))
+           (start (tsc-node-start-position node))
+           (end (tsc-node-end-position
+                 (if (> count 1)
+                     (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count)
+                   node))))
+      (copy-region-as-kill start end))))
+
 
 ;; TODO: TS: capture node
 ;; TODO: TS: clear node
 ;; TODO: TS: comment node
 ;; TODO: TS: delete remaining nodes
 ;; TODO: TS: emit node
-;; TODO: TS: paste node
 ;; TODO: TS: replace node
 ;; TODO: TS: shift forward/backward node
 ;; TODO: TS: splice node
 ;; TODO: TS: swallow node
 ;; TODO: TS: wrap node
-;; TODO: TS: yank node
+;; TODO: TS: yank remaining nodes
 
 ;; TODO: TS: join node ?
 ;; TODO: TS: split node ?

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -28,6 +28,19 @@
 
 (require 'tree-sitter)
 
+(defun symex-ts-append-after ()
+  "Append after symex (instead of vim's default of line)."
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
+    (insert " ")
+    (evil-insert-state)))
+
+(defun symex-ts-change-node-forward (&optional count)
+  "Delete COUNT nodes forward from the current node and enter Insert state."
+  (interactive "p")
+  (save-excursion (symex-ts-delete-node-forward count t))
+  (evil-insert-state 1))
+
 (defun symex-ts-delete-node-backward (&optional count)
   "Delete COUNT nodes backward from the current node."
   (interactive "p")
@@ -67,21 +80,53 @@ too."
     (when (not keep-empty-lines) (symex-ts--delete-current-line-if-empty start-pos))
     (symex-ts-set-current-node-from-point)))
 
-(defun symex-ts-change-node-forward (&optional count)
-  "Delete COUNT nodes forward from the current node and enter Insert state."
-  (interactive "p")
-  (save-excursion (symex-ts-delete-node-forward count t))
-  (evil-insert-state 1))
+(defun symex-ts-insert-at-beginning ()
+  "Insert at beginning of symex."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
+    (evil-insert-state)))
 
-;; TODO: TS: append after node
+(defun symex-ts-insert-at-end ()
+  "Insert at end of symex."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
+    (evil-insert-state)))
+
+(defun symex-ts-insert-before ()
+  "Insert before symex (instead of vim's default at the start of line)."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
+    (insert " ")
+    (backward-char)
+    (evil-insert-state)))
+
+(defun symex-ts-open-line-after ()
+  "Open new line after symex."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
+    (newline-and-indent)
+    (evil-insert-state)))
+
+(defun symex-ts-open-line-before ()
+  "Open new line before symex."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
+    (newline-and-indent)
+    (evil-previous-line)
+    (indent-according-to-mode)
+    (evil-append-line 1)))
+
+
 ;; TODO: TS: capture node
 ;; TODO: TS: clear node
 ;; TODO: TS: comment node
 ;; TODO: TS: delete remaining nodes
 ;; TODO: TS: emit node
-;; TODO: TS: insert at beginning/end of node
-;; TODO: TS: insert before node
-;; TODO: TS: open line before/after node
 ;; TODO: TS: paste node
 ;; TODO: TS: replace node
 ;; TODO: TS: shift forward/backward node

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -86,6 +86,7 @@ selected according to the ranges that have changed."
         (symex-ts-delete-node-forward 1 t)))))
 
 (defun symex-ts-comment (&optional count)
+  "Comment out COUNT expressions."
   (when tree-sitter-mode
     (let* ((count (or count 1))
            (node (symex-ts-get-current-node))

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -58,6 +58,8 @@ selected according to the ranges that have changed."
 
            ;; Update current node from point and reindent if necessary
            (symex-ts-set-current-node-from-point)
+           (when symex-highlight-p
+             (symex--update-overlay))
            (indent-according-to-mode))
 
          ;; Return the result of evaluating BODY

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -166,6 +166,14 @@ too."
     (backward-char)
     (evil-insert-state)))
 
+(defun symex-ts-append-after ()
+  "Append after symex (instead of vim's default of line)."
+  (interactive)
+  (when (symex-ts-get-current-node)
+    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
+    (insert " ")
+    (evil-insert-state)))
+
 (defun symex-ts-open-line-after ()
   "Open new line after symex."
   (interactive)

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -213,6 +213,22 @@ DIRECTION should be either the symbol `before' or `after'."
   (interactive)
   (symex-ts--paste count 'before))
 
+(defun symex-ts-replace ()
+  "Replace contents of symex."
+  (when symex-ts--current-node
+    (let* ((child-count (tsc-count-named-children symex-ts--current-node))
+
+           ;; Get new position for insertion: if the node has children
+           ;; then the start of the first child node, otherwise the
+           ;; current point.
+           (new-pos (if (> child-count 0)
+                        (tsc-node-start-position (tsc-get-nth-named-child symex-ts--current-node 0))
+                      (point))))
+
+      (symex-ts-clear)
+      (goto-char new-pos)
+      (evil-insert-state 1))))
+
 (defun symex-ts-yank (count)
   "Yank (copy) COUNT symexes."
   (interactive "p")
@@ -233,7 +249,6 @@ DIRECTION should be either the symbol `before' or `after'."
 ;; TODO: TS: capture node
 ;; TODO: TS: delete remaining nodes
 ;; TODO: TS: emit node
-;; TODO: TS: replace node
 ;; TODO: TS: shift forward/backward node
 ;; TODO: TS: splice node
 ;; TODO: TS: swallow node

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -85,6 +85,22 @@ selected according to the ranges that have changed."
             (kill-region (tsc-node-start-position first-child) (tsc-node-end-position last-child))))
         (symex-ts-delete-node-forward 1 t)))))
 
+(defun symex-ts-comment (&optional count)
+  (when tree-sitter-mode
+    (let* ((count (or count 1))
+           (node (symex-ts-get-current-node))
+           (start-pos (tsc-node-start-position node))
+           (end-pos (tsc-node-end-position
+                     (if (> count 1)
+                         (symex-ts--get-nth-sibling-from-node
+                          node
+                          #'tsc-get-next-named-sibling count)
+                       node))))
+      (save-excursion (set-mark start-pos)
+                      (goto-char end-pos)
+                      (comment-dwim nil))
+      (symex-ts-set-current-node-from-point))))
+
 (defun symex-ts-delete-node-backward (&optional count)
   "Delete COUNT nodes backward from the current node."
   (interactive "p")
@@ -215,7 +231,6 @@ DIRECTION should be either the symbol `before' or `after'."
 
 
 ;; TODO: TS: capture node
-;; TODO: TS: comment node
 ;; TODO: TS: delete remaining nodes
 ;; TODO: TS: emit node
 ;; TODO: TS: replace node

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -32,6 +32,7 @@
 (require 'evil)
 (require 'evil-surround)
 (require 'evil-cleverparens)  ;; really only need cp-textobjects here
+(require 'symex-primitives)
 (require 'symex-primitives-lisp)
 (require 'symex-utils)
 (require 'symex-traversals)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -66,13 +66,14 @@
   (let ((count (symex--remaining-length)))
     (symex-delete count)))
 
+;; TODO: Modify remaining transformations
+
 (defun symex-change (count)
   "Change COUNT symexes."
   (interactive "p")
-  (let ((start (point))
-        (end (symex--get-end-point count)))
-    (kill-region start end))
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-change-node-forward count)
+    (symex-lisp--change count)))
 
 (defun symex-change-remaining ()
   "Change remaining symexes at this level."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -558,7 +558,7 @@ matched."
 Inserts the prefix at position INDEX in PREFIX-LIST into the buffer at
 point.  If INDEX exceeds the length of the prefix list, then nothing
 is inserted.  This has the effect, when used in succession to
-symex--delete-prefix, of returning the content to an unprefixed state
+`symex--delete-prefix`, of returning the content to an unprefixed state
 after it has cycled once through the prefixes."
   (unless (>= index (length prefix-list))
     (insert (elt prefix-list (max 0 index)))))

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -95,10 +95,12 @@
 (defun symex-replace ()
   "Replace contents of symex."
   (interactive)
-  (symex--clear)
-  (when (or (symex-form-p) (symex-string-p))
-    (forward-char))
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-replace)
+    (progn (symex--clear)
+           (when (or (symex-form-p) (symex-string-p))
+             (forward-char))
+           (symex-enter-lowest))))
 
 (defun symex-clear ()
   "Clear contents of symex."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -103,9 +103,12 @@
 (defun symex-clear ()
   "Clear contents of symex."
   (interactive)
-  (symex--clear)
-  (symex-select-nearest)
-  (symex-tidy))
+  (if tree-sitter-mode
+      (symex-ts-clear)
+    (progn
+      (symex--clear)
+      (symex-select-nearest)
+      (symex-tidy))))
 
 (defun symex--emit-backward ()
   "Emit backward."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -503,8 +503,11 @@ then no action is taken."
 (defun symex-comment (count)
   "Comment out COUNT symexes."
   (interactive "p")
-  (mark-sexp count)
-  (comment-dwim nil))
+  (if tree-sitter-mode
+      (symex-ts-comment count)
+    (progn
+      (mark-sexp count)
+      (comment-dwim nil))))
 
 (defun symex-comment-remaining ()
   "Comment out remaining symexes at this level."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -28,7 +28,7 @@
 (require 'cl-lib)
 
 (require 'symex-transformations-lisp)
-(require 'symex-ts)
+(require 'symex-transformations-ts)
 
 ;; TODO: Remove dependencies after moving to symex-transformations-lisp.el
 (require 'paredit)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -304,54 +304,44 @@ by default, joins next symex to current one."
 (defun symex-open-line-after ()
   "Open new line after symex."
   (interactive)
-  (forward-sexp)
-  (newline-and-indent)
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-open-line-after)
+    (symex-lisp--open-line-after)))
 
 (defun symex-open-line-before ()
   "Open new line before symex."
   (interactive)
-  (newline-and-indent)
-  (evil-previous-line)
-  (indent-according-to-mode)
-  (evil-move-end-of-line)
-  (unless (or (symex--current-line-empty-p)
-              (save-excursion (backward-char)
-                              (lispy-left-p)))
-    (insert " "))
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-open-line-before)
+    (symex-lisp--open-line-before)))
 
 (defun symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)
-  (forward-sexp)  ; selected symexes will have the cursor on the starting paren
-  (insert " ")
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-append-after)
+    (symex-lisp--append-after)))
 
 (defun symex-insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."
   (interactive)
-  (insert " ")
-  (backward-char)
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-insert-before)
+    (symex-lisp--insert-before)))
 
 (defun symex-insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
-  (when (or (lispy-left-p)
-            (symex-string-p))
-    (forward-char))
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-insert-at-beginning)
+    (symex-lisp--insert-at-beginning)))
 
 (defun symex-insert-at-end ()
   "Insert at end of symex."
   (interactive)
-  (if (or (lispy-left-p)
-          (symex-string-p))
-      (progn (forward-sexp)
-             (backward-char))
-    (forward-sexp))
-  (symex-enter-lowest))
+  (if tree-sitter-mode
+      (symex-ts-insert-at-end)
+    (symex-lisp--insert-at-end)))
 
 (defun symex-create (type)
   "Create new symex (list).

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -120,15 +120,14 @@ when the way is blocked.")
 
 (symex-deftraversal symex--traversal-climb-branch
   (protocol (move up)
-            (detour (circuit (move forward))
-                    (move up))
-            (circuit (move forward))))
+            (venture (circuit (move forward))
+                     (move up))))
 
 (symex-deftraversal symex--traversal-descend-branch
   (protocol (precaution symex--traversal-goto-first
                         (beforehand (not (at root))))
             (venture (move down)
-                     (precaution (circuit (move backward))
+                     (precaution symex--traversal-goto-first
                                  (beforehand (not (at root)))))))
 
 (defun symex-traverse-forward (count)

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -69,9 +69,8 @@
   "Select highest symex."
   (interactive)
   (symex-execute-traversal (symex-traversal
-                            (venture (move up)
-                                     (circuit (protocol (circuit (move forward))
-                                                        (move up))))))
+                            (circuit (venture (move up)
+                                              (circuit (move forward))))))
   (point))
 
 (symex-deftraversal symex--traversal-preorder

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -44,7 +44,9 @@
   "Go to last symex on the present branch.")
 
 (symex-deftraversal symex--traversal-goto-lowest
-  (circuit (move down))
+  (circuit
+   (precaution (move down)
+               (beforehand (not (at root)))))
   "Go to lowest (root) symex in present tree.")
 
 (defun symex-goto-first ()

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -69,9 +69,9 @@
   "Select highest symex."
   (interactive)
   (symex-execute-traversal (symex-traversal
-                            (maneuver (move up)
-                                      (circuit (protocol (circuit (move forward))
-                                                         (move up))))))
+                            (venture (move up)
+                                     (circuit (protocol (circuit (move forward))
+                                                        (move up))))))
   (point))
 
 (symex-deftraversal symex--traversal-preorder
@@ -91,16 +91,16 @@
   "Pre-order tree traversal.")
 
 (symex-deftraversal symex--traversal-postorder
-  (protocol (maneuver (move backward)
-                      (circuit (maneuver (move up)
-                                         (circuit (move forward)))))
+  (protocol (venture (move backward)
+                     (circuit (venture (move up)
+                                       (circuit (move forward)))))
             (move down))
   "Post-order tree traversal, continuing to other trees.")
 
 (symex-deftraversal symex--traversal-postorder-in-tree
-  (protocol (precaution (maneuver (move backward)
-                                  (circuit (maneuver (move up)
-                                                     (circuit (move forward)))))
+  (protocol (precaution (venture (move backward)
+                                 (circuit (venture (move up)
+                                                   (circuit (move forward)))))
                         (beforehand (not (at root))))
             (move down))
   "Post-order tree traversal.")
@@ -128,9 +128,9 @@ when the way is blocked.")
 (symex-deftraversal symex--traversal-descend-branch
   (protocol (precaution symex--traversal-goto-first
                         (beforehand (not (at root))))
-            (maneuver (move down)
-                      (precaution (circuit (move backward))
-                                  (beforehand (not (at root)))))))
+            (venture (move down)
+                     (precaution (circuit (move backward))
+                                 (beforehand (not (at root)))))))
 
 (defun symex-traverse-forward (count)
   "Traverse symex as a tree, using pre-order traversal.

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -165,6 +165,12 @@ Automatically set it to the node at point if necessary."
   "Set the current node to the top-most node at point."
   (symex-ts--set-current-node (symex-ts-get-topmost-node-at-point)))
 
+(defun symex-ts-at-root-p ()
+  "Check whether the current node is the root node."
+  (let ((root (tsc-root-node tree-sitter-tree))
+        (cur (symex-ts-get-current-node)))
+    (tsc-node-eq cur root)))
+
 (defun symex-ts-get-topmost-node-at-point ()
   "Return the top-most node at the current point."
   (let ((root (tsc-root-node tree-sitter-tree))

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -306,9 +306,14 @@ too."
     (when (not keep-empty-lines) (symex-ts--delete-current-line-if-empty start-pos))
     (symex-ts-set-current-node-from-point)))
 
+(defun symex-ts-change-node-forward (&optional count)
+  "Delete COUNT nodes forward from the current node and enter Insert state."
+  (interactive "p")
+  (save-excursion (symex-ts-delete-node-forward count t))
+  (evil-insert-state 1))
+
 ;; TODO: TS: append after node
 ;; TODO: TS: capture node
-;; TODO: TS: change node
 ;; TODO: TS: clear node
 ;; TODO: TS: comment node
 ;; TODO: TS: delete remaining nodes

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -258,6 +258,10 @@ Move COUNT times, defaulting to 1."
   (interactive "p")
   (symex-ts--move-with-count #'symex-ts--descend-to-child-with-sibling (symex-make-move 0 1) count))
 
+(defun symex-ts--exit ()
+  "Take necessary tree-sitter related actions upon exiting Symex mode."
+  (symex-ts--delete-overlay))
+
 
 (provide 'symex-ts)
 ;;; symex-ts.el ends here

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -110,16 +110,22 @@ leaf."
           (symex-ts--descend-to-child-with-sibling child))
       nil)))
 
-(defun symex-ts--ascend-to-parent-with-sibling (node)
+(defun symex-ts--ascend-to-parent-with-sibling (node &optional initial)
   "Ascend from NODE to parent recursively.
 
 Recursion will end when the parent node has a sibling or is the
 root."
-  (let ((parent (tsc-get-parent node)))
+  (let ((parent (tsc-get-parent node))
+        (initial (or initial node)))
     (if parent
-        (if (symex-ts--node-has-sibling-p parent)
-            parent
-          (symex-ts--ascend-to-parent-with-sibling parent))
+        ;; visit node if it either has no siblings or changes point,
+        ;; for symmetry with "descend" behavior
+        (cond ((and (not (= (tsc-node-start-position node)
+                            (tsc-node-start-position parent)))
+                    (not (tsc-node-eq node initial)))
+               node)
+              ((symex-ts--node-has-sibling-p parent) parent)
+              (t (symex-ts--ascend-to-parent-with-sibling parent node)))
       node)))
 
 (defun symex-ts--move-with-count (fn move-delta &optional count)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -267,6 +267,66 @@ Move COUNT times, defaulting to 1."
   (interactive "p")
   (symex-ts--move-with-count #'symex-ts--descend-to-child-with-sibling (symex-make-move 0 1) count))
 
+(defun symex-ts-delete-node-backward (&optional count)
+  "Delete COUNT nodes backward from the current node."
+  (interactive "p")
+  (let* ((count (or count 1))
+         (node (tsc-get-prev-named-sibling (symex-ts-get-current-node))))
+    (when node
+      (let ((end-pos (tsc-node-end-position node))
+            (start-pos (tsc-node-start-position
+                        (if (> count 1)
+                            (symex-ts--get-nth-sibling-from-node node #'tsc-get-prev-named-sibling count)
+                          node))))
+        (kill-region start-pos end-pos)
+        (symex-ts--delete-current-line-if-empty start-pos)
+        (symex-ts-set-current-node-from-point)))))
+
+(defun symex-ts-delete-node-forward (&optional count keep-empty-lines)
+  "Delete COUNT nodes forward from the current node.
+
+If KEEP-EMPTY-LINES is set then if the deletion results in an
+empty line it will be kept. By default empty lines are deleted
+too."
+  (interactive "p")
+  (let* ((count (or count 1))
+         (node (symex-ts-get-current-node))
+         (next-node (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count))
+         (start-pos (tsc-node-start-position node))
+         (end-pos (tsc-node-end-position
+                   (if (> count 1)
+                       (symex-ts--get-nth-sibling-from-node node #'tsc-get-next-named-sibling count)
+                     node))))
+
+    (if next-node
+        (symex-ts--set-current-node next-node)
+      (symex-ts-set-current-node-from-point))
+    (kill-region start-pos end-pos)
+
+    (when (not keep-empty-lines) (symex-ts--delete-current-line-if-empty start-pos))
+    (symex-ts-set-current-node-from-point)))
+
+;; TODO: TS: append after node
+;; TODO: TS: capture node
+;; TODO: TS: change node
+;; TODO: TS: clear node
+;; TODO: TS: comment node
+;; TODO: TS: delete remaining nodes
+;; TODO: TS: emit node
+;; TODO: TS: insert at beginning/end of node
+;; TODO: TS: insert before node
+;; TODO: TS: open line before/after node
+;; TODO: TS: paste node
+;; TODO: TS: replace node
+;; TODO: TS: shift forward/backward node
+;; TODO: TS: splice node
+;; TODO: TS: swallow node
+;; TODO: TS: wrap node
+;; TODO: TS: yank node
+
+;; TODO: TS: join node ?
+;; TODO: TS: split node ?
+
 ;;; Utilities
 
 (defmacro symex-ts-save-excursion (&rest body)
@@ -340,6 +400,14 @@ indicated by point."
 (defun symex-ts--exit ()
   "Take necessary tree-sitter related actions upon exiting Symex mode."
   (setq-local symex-ts--current-node nil))
+
+(defun symex-ts--delete-current-line-if-empty (point)
+  "Delete the line containing POINT if it is empty."
+  (save-excursion (goto-char point)
+                  (when (string-match "^[[:space:]]*$" (buffer-substring-no-properties (point-at-bol) (point-at-eol)))
+                    (kill-whole-line)
+                    (pop kill-ring)
+                    (setq kill-ring-yank-pointer kill-ring))))
 
 
 (provide 'symex-ts)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -214,7 +214,7 @@ Automatically set it to the node at point if necessary."
 Note that this does not consider global root to be a tree root."
   (let ((root (tsc-root-node tree-sitter-tree))
         (cur (symex-ts-get-current-node)))
-    (let ((parent (tsc-get-parent cur)))
+    (let ((parent (symex-ts--ascend-to-parent-with-sibling cur)))
       (and parent (tsc-node-eq parent root)))))
 
 (defun symex-ts--at-first-p ()

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -36,6 +36,8 @@
 (require 'symex-utils-ts)
 
 
+(defvar-local symex-ts--current-node nil "The current Tree Sitter node.")
+
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -36,30 +36,6 @@
 (require 'symex-utils-ts)
 
 
-(defface symex-ts-current-node-face
-  '((t :inherit highlight :extend nil))
-  "Face used to highlight the current tree node."
-  :group 'symex-faces)
-
-
-(defvar symex-ts--current-node nil "The current Tree Sitter node.")
-
-(defun symex-ts--delete-overlay ()
-  "Delete the highlight overlay."
-  (when symex-ts--current-overlay
-    (delete-overlay symex-ts--current-overlay)))
-
-(defun symex-ts--update-overlay (node)
-  "Update the highlight overlay to match the start/end position of NODE."
-  (when symex-ts--current-overlay
-    (delete-overlay symex-ts--current-overlay))
-  (setq-local symex-ts--current-overlay (make-overlay (tsc-node-start-position node) (tsc-node-end-position node)))
-  (overlay-put symex-ts--current-overlay 'face 'symex-ts-current-node-face))
-
-(defun symex-ts--exit ()
-  "Take necessary tree-sitter related actions upon exiting Symex mode."
-  (symex-ts--delete-overlay))
-
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -177,6 +177,12 @@ Automatically set it to the node at point if necessary."
         (p (point)))
     (symex-ts--get-topmost-node (tsc-get-named-descendant-for-position-range root p p))))
 
+;;; User Interface
+
+(defun symex-ts--adjust-point ()
+  "Helper to adjust point to indicate the correct symex."
+  nil)
+
 ;;; Predicates
 
 (defmacro symex-ts--if-stuck (do-what operation &rest body)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -42,8 +42,16 @@
 
 (defvar symex-ts--current-node nil "The current Tree Sitter node.")
 
-(defvar symex-ts--current-overlay nil "The current overlay which highlights the current node.")
+(defun symex-ts--get-starting-point ()
+  "Get the point value at the start of the current symex."
+  (tsc-node-start-position symex-ts--current-node))
 
+(defun symex-ts--get-end-point (count)
+  "Get the point value after COUNT symexes.
+
+If the containing expression terminates earlier than COUNT
+symexes, returns the end point of the last one found."
+  (tsc-node-end-position symex-ts--current-node))
 
 (defun symex-ts--delete-overlay ()
   "Delete the highlight overlay."

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -214,8 +214,8 @@ Automatically set it to the node at point if necessary."
 Note that this does not consider global root to be a tree root."
   (let ((root (tsc-root-node tree-sitter-tree))
         (cur (symex-ts-get-current-node)))
-    (let ((parent (symex-ts--ascend-to-parent-with-sibling cur)))
-      (and parent (tsc-node-eq parent root)))))
+    (let ((parent (tsc-get-parent cur)))
+      (or (not parent) (tsc-node-eq parent root)))))
 
 (defun symex-ts--at-first-p ()
   "Check if the current node is the first one at some level."

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -68,8 +68,7 @@ symexes, returns the end point of the last one found."
 (defun symex-ts--set-current-node (node)
   "Set the current node to NODE and update internal references."
   (setq-local symex-ts--current-node node)
-  (goto-char (tsc-node-start-position node))
-  (symex-ts--update-overlay symex-ts--current-node))
+  (goto-char (tsc-node-start-position node)))
 
 (defun symex-ts--get-topmost-node (node)
   "Return the highest node in the tree starting from NODE.
@@ -163,11 +162,6 @@ Return a Symex move (list with x,y node offsets tagged with
     ;; Return the Symex move that was executed, or nil to signify that
     ;; the movement failed
     (when (not (symex--are-moves-equal-p move symex--move-zero)) move)))
-
-(defun symex-ts--after-tree-modification ()
-  "Handle any tree modification."
-  (symex-ts--delete-overlay)
-  (setq-local symex-ts--current-node nil))
 
 (defun symex-ts-current-node-sexp ()
   "Print the current node as an s-expression."
@@ -288,7 +282,7 @@ Move COUNT times, defaulting to 1."
 
 (defun symex-ts--exit ()
   "Take necessary tree-sitter related actions upon exiting Symex mode."
-  (symex-ts--delete-overlay))
+  (setq-local symex-ts--current-node nil))
 
 
 (provide 'symex-ts)

--- a/symex-ui.el
+++ b/symex-ui.el
@@ -28,12 +28,38 @@
 
 (require 'symex-custom)
 
+(defface symex--current-node-face
+  '((t :inherit highlight :extend nil))
+  "Face used to highlight the current tree node."
+  :group 'symex-faces)
+
+(defvar symex--current-overlay nil "The current overlay which highlights the current node.")
+
+(defun symex--delete-overlay ()
+  "Delete the highlight overlay."
+  (when symex--current-overlay
+    (delete-overlay symex--current-overlay)))
+
+(defun symex--update-overlay ()
+  "Update the highlight overlay to match the start/end position of NODE."
+  (when symex--current-overlay
+    (delete-overlay symex--current-overlay))
+  (setq-local symex--current-overlay
+              (make-overlay (symex--get-starting-point)
+                            (symex--get-end-point 1)))
+  (overlay-put symex--current-overlay 'face 'symex--current-node-face))
+
+(defun symex--overlay-active-p ()
+  "Is the overlay active?"
+  (and symex--current-overlay
+       (overlay-start symex--current-overlay)))
+
 (defun symex--toggle-highlight ()
   "Toggle highlighting of selected symex."
   (interactive)
-  (if mark-active
-      (deactivate-mark)
-    (mark-sexp))
+  (if (symex--overlay-active-p)
+      (symex--delete-overlay)
+    (symex--update-overlay))
   (setq symex-highlight-p
         (not symex-highlight-p)))
 

--- a/symex-utils-ts.el
+++ b/symex-utils-ts.el
@@ -1,0 +1,37 @@
+;;; symex-utils-ts.el --- An evil way to edit Lisp symbolic expressions as trees -*- lexical-binding: t -*-
+
+;; URL: https://github.com/countvajhula/symex.el
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; Generic utilities used by symex (Tree Sitter) mode
+
+;;; Code:
+
+(defun symex-ts--delete-current-line-if-empty (point)
+  "Delete the line containing POINT if it is empty."
+  (save-excursion (goto-char point)
+                  (when (string-match "^[[:space:]]*$" (buffer-substring-no-properties (point-at-bol) (point-at-eol)))
+                    (kill-whole-line)
+                    (pop kill-ring)
+                    (setq kill-ring-yank-pointer kill-ring))))
+
+(provide 'symex-utils-ts)
+;;; symex-utils-ts.el ends here

--- a/symex-utils-ts.el
+++ b/symex-utils-ts.el
@@ -31,7 +31,8 @@
                   (when (string-match "^[[:space:]]*$" (buffer-substring-no-properties (point-at-bol) (point-at-eol)))
                     (kill-whole-line)
                     (pop kill-ring)
-                    (setq kill-ring-yank-pointer kill-ring))))
+                    (setq kill-ring-yank-pointer kill-ring)
+                    t)))
 
 (provide 'symex-utils-ts)
 ;;; symex-utils-ts.el ends here

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -44,9 +44,9 @@ From: https://stackoverflow.com/a/13313091"
                      (point))
      (point)))
 
-;;; `with-undo-collapse` macro, to treat a sequence of operations
-;;; as a single entry in the undo list.
-;;; From: https://emacs.stackexchange.com/questions/7558/collapsing-undo-history/7560#7560
+;; `with-undo-collapse` macro, to treat a sequence of operations
+;; as a single entry in the undo list.
+;; From: https://emacs.stackexchange.com/questions/7558/collapsing-undo-history/7560#7560
 (defun symex--undo-collapse-begin (marker)
   "Mark the beginning of a collapsible undo block.
 

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -103,7 +103,7 @@ result."
   "Compute the remaining length of the current symex.
 
 This should be done via DSL computation semantics at some point."
-  (save-excursion
+  (symex-save-excursion
     (let ((result (symex-execute-traversal symex--traversal-goto-last)))
      (1+ (length result)))))
 

--- a/symex.el
+++ b/symex.el
@@ -160,8 +160,10 @@ advises functions to enable or disable features based on user configuration."
     (advice-add #'symex-go-up :around #'symex--return-to-branch-position)
     (advice-add #'symex-go-backward :around #'symex--forget-branch-positions)
     (advice-add #'symex-go-forward :around #'symex--forget-branch-positions))
-  (advice-add #'undo-tree-undo :after #'symex-select-nearest-advice)
-  (advice-add #'undo-tree-redo :after #'symex-select-nearest-advice)
+  (when (fboundp 'undo-tree-undo)
+    (advice-add #'undo-tree-undo :after #'symex-select-nearest-advice))
+  (when (fboundp 'undo-tree-redo)
+    (advice-add #'undo-tree-redo :after #'symex-select-nearest-advice))
   (symex--add-selection-advice)
   ;; initialize modal interface frontend
   (cond ((eq symex-modal-backend 'hydra)
@@ -188,8 +190,10 @@ configuration to be disabled and the new one adopted."
   (advice-remove #'symex-go-up #'symex--return-to-branch-position)
   (advice-remove #'symex-go-backward #'symex--forget-branch-positions)
   (advice-remove #'symex-go-forward #'symex--forget-branch-positions)
-  (advice-remove #'undo-tree-undo #'symex-select-nearest-advice)
-  (advice-remove #'undo-tree-redo #'symex-select-nearest-advice)
+  (when (fboundp 'undo-tree-undo)
+    (advice-remove #'undo-tree-undo #'symex-select-nearest-advice))
+  (when (fboundp 'undo-tree-redo)
+    (advice-remove #'undo-tree-redo #'symex-select-nearest-advice))
   (symex--remove-selection-advice))
 
 ;;;###autoload

--- a/symex.el
+++ b/symex.el
@@ -47,6 +47,7 @@
 (require 'symex-evil)
 (require 'symex-interop)
 (require 'symex-misc)
+(require 'symex-primitives)
 (require 'symex-custom)
 (require 'tree-sitter)
 (require 'symex-ts)

--- a/symex.el
+++ b/symex.el
@@ -116,8 +116,6 @@
   (symex--adjust-point-on-entry)
   (when symex-remember-branch-positions-p
     (symex--clear-branch-memory))
-  (when tree-sitter-mode
-    (symex-ts-set-current-node-from-point))
   (symex-select-nearest)
   (when symex-refocus-p
     ;; smooth scrolling currently not supported

--- a/symex.el
+++ b/symex.el
@@ -160,6 +160,8 @@ advises functions to enable or disable features based on user configuration."
     (advice-add #'symex-go-up :around #'symex--return-to-branch-position)
     (advice-add #'symex-go-backward :around #'symex--forget-branch-positions)
     (advice-add #'symex-go-forward :around #'symex--forget-branch-positions))
+  (advice-add #'undo-tree-undo :after #'symex-select-nearest-advice)
+  (advice-add #'undo-tree-redo :after #'symex-select-nearest-advice)
   (symex--add-selection-advice)
   ;; initialize modal interface frontend
   (cond ((eq symex-modal-backend 'hydra)
@@ -186,6 +188,8 @@ configuration to be disabled and the new one adopted."
   (advice-remove #'symex-go-up #'symex--return-to-branch-position)
   (advice-remove #'symex-go-backward #'symex--forget-branch-positions)
   (advice-remove #'symex-go-forward #'symex--forget-branch-positions)
+  (advice-remove #'undo-tree-undo #'symex-select-nearest-advice)
+  (advice-remove #'undo-tree-redo #'symex-select-nearest-advice)
   (symex--remove-selection-advice))
 
 ;;;###autoload


### PR DESCRIPTION
### Summary of Changes

Use tree-sitter for non-lisps.

### Remaining Work

✨ See the [Kanban Board](https://github.com/users/countvajhula/projects/1/views/1). 📒

**Older completed items**:
- [x] Groundwork and basic movements (PR: #32)
- [x] Fix `leap-branch` (see [this comment](https://github.com/countvajhula/symex.el/pull/32#issuecomment-955596203)) (PR: #42)
- [x] Add basic transformations (e.g. d, c, y, p) (PR: #47)
