### PR TITLE
Evil repeat

### DIFF
--- a/symex-evil.el
+++ b/symex-evil.el
@@ -240,42 +240,60 @@ executing this command to get the expected behavior."
   "User key specification overrides for symex evil state.")
 
 (defvar symex--evil-repeatable-commands
-  '(symex-create-round
+  '(paredit-raise-sexp
+    symex-add-quoting-level
+    symex-append-newline
+    symex-capture-backward
+    symex-capture-forward
+    symex-change
+    symex-clear
+    symex-comment
+    symex-comment-remaining
+    symex-create-round
     symex-create-square
-    symex-wrap-round
-    symex-wrap-square
     symex-cycle-quote
     symex-cycle-unquote
-    symex-add-quoting-level
-    symex-remove-quoting-level
-    symex-paste-after
-    symex-paste-before
     symex-delete
     symex-delete-backwards
     symex-delete-remaining
-    symex-clear
-    symex-shift-backward
-    symex-shift-forward
-    symex-shift-backward-most
-    symex-shift-forward-most
-    paredit-raise-sexp
-    symex-capture-backward
     symex-emit-backward
-    symex-capture-forward
     symex-emit-forward
+    symex-insert-newline
+    symex-join
+    symex-join-lines
+    symex-join-lines-backwards
+    symex-open-line-after
+    symex-open-line-before
+    symex-paste-after
+    symex-paste-before
+    symex-remove-quoting-level
+    symex-shift-backward
+    symex-shift-backward-most
+    symex-shift-forward
+    symex-shift-forward-most
+    symex-splice
+    symex-split
     symex-swallow
     symex-swallow-tail
-    symex-split
-    symex-join
-    symex-splice
-    symex-insert-newline
-    symex-join-lines-backwards
-    symex-append-newline
-    symex-join-lines
     symex-tidy
     symex-wrap
-    symex-comment
-    symex-comment-remaining)
+    symex-wrap-round
+    symex-wrap-square
+    symex-append-after
+    symex-change-delimiter
+    symex-change-remaining
+    symex-collapse
+    symex-collapse-remaining
+    symex-insert-at-beginning
+    symex-insert-at-end
+    symex-insert-before
+    symex-open-line-after
+    symex-open-line-before
+    symex-tidy-proper
+    symex-tidy-remaining
+    symex-unfurl
+    symex-unfurl-remaining
+    symex-wrap-and-append)
   "Commands which should have their `:repeat' property set to `t'.")
 
 (defun symex-evil-initialize ()


### PR DESCRIPTION
### Summary of Changes

Integrates symex-evil.el with evil-repeat.el by advising key `evil-repeat` related functions. Mainly, this sets up behavior to:

1. Start and stop repeatition recording in `pre-` and `post-command-hook`2. 
2. Sets the `:repeat` property for a bunch of symex commands to `t`.
3. Ensures that symex state is preserved after completing a repitition.

### Public Domain Dedication

- [ x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
