### PR TITLE
Macros for defining symex commands

### DIFF
--- a/symex-evil.el
+++ b/symex-evil.el
@@ -313,6 +313,9 @@ executing this command to get the expected behavior."
               :after #'symex-evil-repeat-stop-recording-advice)
   (advice-add 'evil-repeat
               :around #'symex-evil-repeat-preserve-state-advice)
+  ;; TODO: once all the commands are defined using the macro,
+  ;; add this declaration to the macro definition and remove
+  ;; the "registration" here.
   (dolist (fn symex--evil-repeatable-commands)
     (evil-add-command-properties fn :repeat t)))
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -141,8 +141,7 @@
   "Append after symex (instead of vim's default of line)."
   (interactive)
   (forward-sexp)  ; selected symexes will have the cursor on the starting paren
-  (insert " ")
-  (symex-enter-lowest))
+  (insert " "))
 
 (defun symex-lisp--open-line-after ()
   "Open new line after symex."
@@ -166,16 +165,14 @@
   "Insert before symex (instead of vim's default at the start of line)."
   (interactive)
   (insert " ")
-  (backward-char)
-  (symex-enter-lowest))
+  (backward-char))
 
 (defun symex-lisp--insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
   (when (or (lispy-left-p)
             (symex-string-p))
-    (forward-char))
-  (symex-enter-lowest))
+    (forward-char)))
 
 (defun symex-lisp--insert-at-end ()
   "Insert at end of symex."
@@ -184,8 +181,7 @@
           (symex-string-p))
       (progn (forward-sexp)
              (backward-char))
-    (forward-sexp))
-  (symex-enter-lowest))
+    (forward-sexp)))
 
 (defun symex-lisp--paste-after ()
   "Paste after symex."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -161,8 +161,7 @@
   (unless (or (symex--current-line-empty-p)
               (save-excursion (backward-char)
                               (lispy-left-p)))
-    (insert " "))
-  (symex-enter-lowest))
+    (insert " ")))
 
 (defun symex-lisp--insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -65,6 +65,18 @@
                       (list start end))))))
   (symex-select-nearest))
 
+(defun symex-lisp-clear ()
+  "Helper to clear contents of symex."
+  (cond ((symex-opening-round-p)
+         (apply #'evil-delete (evil-inner-paren)))
+        ((symex-opening-square-p)
+         (apply #'evil-delete (evil-inner-bracket)))
+        ((symex-opening-curly-p)
+         (apply #'evil-delete (evil-inner-curly)))
+        ((symex-string-p)
+         (apply #'evil-delete (evil-inner-double-quote)))
+        (t (kill-sexp))))
+
 (defun symex-lisp--delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -62,8 +62,7 @@
              ;; maybe we should just always use this instead
              (save-excursion
                (apply #'evil-indent
-                      (list start end))))))
-  (symex-select-nearest))
+                      (list start end)))))))
 
 (defun symex-lisp-clear ()
   "Helper to clear contents of symex."
@@ -201,7 +200,7 @@
       (insert extra-to-prepend)
       (evil-paste-before nil nil))
     (symex--go-forward)
-    (symex-tidy)))
+    (symex-lisp-tidy)))
 
 (defun symex-lisp--paste-before ()
   "Paste before symex."
@@ -220,8 +219,7 @@
           (forward-char))
         (insert extra-to-append))
       (symex--go-forward)
-      (symex-tidy))
-    (symex-tidy)))
+      (symex-lisp-tidy))))
 
 (defun symex-lisp--yank (count)
   "Yank (copy) COUNT symexes."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -120,16 +120,14 @@
         ((save-excursion (forward-char) ; ... <>)
                          (lispy-right-p))
          (symex--go-backward))
-        (t (symex--go-forward)))
-  (symex-select-nearest)
-  (symex-tidy))
+        (t (symex--go-forward))))
 
 (defun symex-lisp--delete-backwards (count)
   "Delete COUNT symexes backwards."
   (interactive "p")
   (dotimes (_ count)
     (when (symex--go-backward)
-      (symex-delete 1))))
+      (symex-lisp--delete 1))))
 
 (defun symex-lisp--change (count)
   "Change COUNT symexes."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -83,6 +83,7 @@
     (forward-char))
   (symex-enter-lowest))
 
+;; TODO: rename these to reflect non-private
 (defun symex-lisp--delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -77,6 +77,12 @@
          (apply #'evil-delete (evil-inner-double-quote)))
         (t (kill-sexp))))
 
+(defun symex-lisp-replace ()
+  (symex-lisp-clear)
+  (when (or (symex-form-p) (symex-string-p))
+    (forward-char))
+  (symex-enter-lowest))
+
 (defun symex-lisp--delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -83,14 +83,17 @@
     (forward-char))
   (symex-enter-lowest))
 
-;; TODO: rename these to reflect non-private
 (defun symex-lisp--delete (count)
   "Delete COUNT symexes."
-  (interactive "p")
   (let ((last-command nil)  ; see symex-yank re: last-command
         (start (point))
         (end (symex--get-end-point count)))
-    (kill-region start end))
+    (kill-region start end)))
+
+(defun symex-lisp-delete (count)
+  "Delete COUNT symexes."
+  (interactive "p")
+  (symex-lisp--delete count)
   (cond ((or (symex--current-line-empty-p)         ; ^<>$
              (save-excursion (evil-last-non-blank) ; (<>$
                              (lispy-left-p))
@@ -122,20 +125,20 @@
          (symex--go-backward))
         (t (symex--go-forward))))
 
+;; TODO: rename these to reflect non-private
 (defun symex-lisp--delete-backwards (count)
   "Delete COUNT symexes backwards."
   (interactive "p")
   (dotimes (_ count)
     (when (symex--go-backward)
-      (symex-lisp--delete 1))))
+      (symex-lisp-delete 1))))
 
 (defun symex-lisp--change (count)
   "Change COUNT symexes."
   (interactive "p")
   (let ((start (point))
         (end (symex--get-end-point count)))
-    (kill-region start end))
-  (symex-enter-lowest))
+    (kill-region start end)))
 
 (defun symex-lisp--append-after ()
   "Append after symex (instead of vim's default of line)."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -41,6 +41,30 @@
 ;;; TRANSFORMATIONS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;
 
+(defun symex-lisp-tidy ()
+  "Auto-indent symex and fix any whitespace."
+  (fixup-whitespace)
+  (when (save-excursion (looking-at-p "[[:space:]]"))
+    (forward-char))
+  (condition-case nil
+      (save-excursion
+        (forward-sexp)
+        (fixup-whitespace))
+    (error nil))
+  (condition-case err
+      (save-excursion
+        (apply #'evil-indent
+               (seq-take (evil-cp-a-form 1)
+                         2)))
+    (error (message "[Symex] symex-tidy: suppressed error %S" err)
+           (let ((start (point))
+                 (end (save-excursion (forward-sexp) (point))))
+             ;; maybe we should just always use this instead
+             (save-excursion
+               (apply #'evil-indent
+                      (list start end))))))
+  (symex-select-nearest))
+
 (defun symex-lisp--delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -149,8 +149,7 @@
   "Open new line after symex."
   (interactive)
   (forward-sexp)
-  (newline-and-indent)
-  (symex-enter-lowest))
+  (newline-and-indent))
 
 (defun symex-lisp--open-line-before ()
   "Open new line before symex."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -254,6 +254,10 @@ DIRECTION should be either the symbol `before' or `after'."
                    node))))
       (copy-region-as-kill start end))))
 
+(defun symex-ts-tidy ()
+  "Auto-indent symex and fix any whitespace."
+  nil)
+
 
 ;; TODO: TS: capture node
 ;; TODO: TS: delete remaining nodes

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -54,13 +54,7 @@ selected according to the ranges that have changed."
              ;; If the change starts on a carriage return, move
              ;; forward one character
              (when (char-equal ?\C-j (char-after))
-               (forward-char 1)))
-
-           ;; Update current node from point and reindent if necessary
-           (symex-ts-set-current-node-from-point)
-           (when symex-highlight-p
-             (symex--update-overlay))
-           (indent-according-to-mode))
+               (forward-char 1))))
 
          ;; Return the result of evaluating BODY
          ,res))))
@@ -255,7 +249,8 @@ DIRECTION should be either the symbol `before' or `after'."
 
 (defun symex-ts-tidy ()
   "Auto-indent symex and fix any whitespace."
-  nil)
+  ;; Update current node from point and reindent if necessary
+  (indent-according-to-mode))
 
 
 ;; TODO: TS: capture node

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -179,8 +179,7 @@ too."
   (interactive)
   (when (symex-ts-get-current-node)
     (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
-    (newline-and-indent)
-    (evil-insert-state)))
+    (newline-and-indent)))
 
 (defun symex-ts-open-line-before ()
   "Open new line before symex."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -108,8 +108,7 @@ selected according to the ranges that have changed."
                             (symex-ts--get-nth-sibling-from-node node #'tsc-get-prev-named-sibling count)
                           node))))
         (kill-region start-pos end-pos)
-        (symex-ts--delete-current-line-if-empty start-pos)
-        (symex-ts-set-current-node-from-point)))))
+        (symex-ts--delete-current-line-if-empty start-pos)))))
 
 (defun symex-ts-delete-node-forward (&optional count keep-empty-lines)
   "Delete COUNT nodes forward from the current node.

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -233,8 +233,7 @@ DIRECTION should be either the symbol `before' or `after'."
                       (point))))
 
       (symex-ts-clear)
-      (goto-char new-pos)
-      (evil-insert-state 1))))
+      (goto-char new-pos))))
 
 (defun symex-ts-yank (count)
   "Yank (copy) COUNT symexes."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -189,7 +189,7 @@ too."
     (newline-and-indent)
     (evil-previous-line)
     (indent-according-to-mode)
-    (evil-append-line 1)))
+    (move-end-of-line 1)))
 
 (defun symex-ts--paste (count direction)
   "Paste before or after symex, COUNT times, according to DIRECTION.

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -140,15 +140,13 @@ too."
   "Insert at beginning of symex."
   (interactive)
   (when (symex-ts-get-current-node)
-    (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
-    (evil-insert-state)))
+    (goto-char (tsc-node-start-position (symex-ts-get-current-node)))))
 
 (defun symex-ts-insert-at-end ()
   "Insert at end of symex."
   (interactive)
   (when (symex-ts-get-current-node)
-    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))
-    (evil-insert-state)))
+    (goto-char (tsc-node-end-position (symex-ts-get-current-node)))))
 
 (defun symex-ts-insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."
@@ -156,8 +154,16 @@ too."
   (when (symex-ts-get-current-node)
     (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
     (insert " ")
-    (backward-char)
-    (evil-insert-state)))
+    (backward-char)))
+
+(defun symex-ts-append-after ()
+  "Append after the end of the symex.
+
+Since non-Lisp languages don't really have a syntactic distinction
+between the inside and the outside of expressions, this is just an
+alias for inserting at the end."
+  (interactive)
+  (symex-ts-insert-at-end))
 
 (defun symex-ts-append-after ()
   "Append after symex (instead of vim's default of line)."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -656,27 +656,9 @@ layer of quoting."
 (defun symex-tidy ()
   "Auto-indent symex and fix any whitespace."
   (interactive)
-  (fixup-whitespace)
-  (when (save-excursion (looking-at-p "[[:space:]]"))
-    (forward-char))
-  (condition-case nil
-      (save-excursion
-        (forward-sexp)
-        (fixup-whitespace))
-    (error nil))
-  (condition-case err
-      (save-excursion
-        (apply #'evil-indent
-               (seq-take (evil-cp-a-form 1)
-                         2)))
-    (error (message "[Symex] symex-tidy: suppressed error %S" err)
-           (let ((start (point))
-                 (end (save-excursion (forward-sexp) (point))))
-             ;; maybe we should just always use this instead
-             (save-excursion
-               (apply #'evil-indent
-                      (list start end))))))
-  (symex-select-nearest))
+  (if tree-sitter-mode
+      (symex-ts-tidy)
+    (symex-lisp-tidy)))
 
 (cl-defun symex--transform-in-isolation (traversal side-effect &key pre-traversal)
   "Transform a symex in a temporary buffer and replace the original with it.

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -102,6 +102,12 @@
              (forward-char))
            (symex-enter-lowest))))
 
+;; TODO: `symex-define-command` macro
+;; - write the wrapping code before and after without needing advice
+;; - select-nearest etc. after, and remove the ad hoc cases
+;; - this would also allow more fine-grained handling, e.g. different types of commands
+;; - this would also avoid the need for `symex--evil-repeatable-commands`, so that we could `(evil-add-command-properties fn :repeat t)` directly -- this would also support users defining new symex commands and having them be repeatable without a manual registration process
+
 (defun symex-clear ()
   "Clear contents of symex."
   (interactive)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -46,6 +46,7 @@
 ;;; TRANSFORMATIONS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;
 
+;; TODO: define these using the symex command macro
 (defun symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
@@ -286,6 +287,7 @@ by default, joins next symex to current one."
       (symex-ts-open-line-before)
     (symex-lisp--open-line-before)))
 
+;; TODO: define the rest as insertion commands
 (defun symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -60,10 +60,17 @@
      (symex-select-nearest)
      (symex-tidy)))
 
-(defmacro symex-define-insertion-command (name args docstring &rest body)
+(defmacro symex-define-insertion-command (name
+                                          args
+                                          docstring
+                                          interactive-decl
+                                          &rest
+                                          body)
   "Define a symex command that enters an insertion state."
   `(defun ,name ,args
      ,docstring
+     ,interactive-decl
+     (evil-start-undo-step)
      ,@body
      (symex-enter-lowest)))
 

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -108,6 +108,14 @@
 ;; - this would also allow more fine-grained handling, e.g. different types of commands
 ;; - this would also avoid the need for `symex--evil-repeatable-commands`, so that we could `(evil-add-command-properties fn :repeat t)` directly -- this would also support users defining new symex commands and having them be repeatable without a manual registration process
 
+(defmacro symex-define-command (name args docstring &rest body)
+  "Define a symex command."
+  `(defun ,name ,args
+     ,docstring
+     ,@body
+     (symex-select-nearest)
+     (symex-tidy)))
+
 (defun symex-clear ()
   "Clear contents of symex."
   (interactive)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -54,6 +54,7 @@
 
 (defmacro symex-define-command (name args docstring &rest body)
   "Define a symex command."
+  (declare (indent defun))
   `(defun ,name ,args
      ,docstring
      ,@body
@@ -67,6 +68,7 @@
                                           &rest
                                           body)
   "Define a symex command that enters an insertion state."
+  (declare (indent defun))
   `(defun ,name ,args
      ,docstring
      ,interactive-decl

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -101,6 +101,13 @@
      (symex-select-nearest)
      (symex-tidy)))
 
+(defmacro symex-define-insertion-command (name args docstring &rest body)
+  "Define a symex command that enters an insertion state."
+  `(defun ,name ,args
+     ,docstring
+     ,@body
+     (symex-enter-lowest)))
+
 (symex-define-command symex-clear ()
   "Clear contents of symex."
   (interactive)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -272,7 +272,7 @@ by default, joins next symex to current one."
       (dotimes (_ count)
         (symex-lisp--paste-after)))))
 
-(defun symex-open-line-after ()
+(symex-define-insertion-command symex-open-line-after ()
   "Open new line after symex."
   (interactive)
   (if tree-sitter-mode

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -46,7 +46,27 @@
 ;;; TRANSFORMATIONS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: define these using the symex command macro
+;; TODO: `symex-define-command` macro
+;; - write the wrapping code before and after without needing advice
+;; - select-nearest etc. after, and remove the ad hoc cases
+;; - this would also allow more fine-grained handling, e.g. different types of commands
+;; - this would also avoid the need for `symex--evil-repeatable-commands`, so that we could `(evil-add-command-properties fn :repeat t)` directly -- this would also support users defining new symex commands and having them be repeatable without a manual registration process
+
+(defmacro symex-define-command (name args docstring &rest body)
+  "Define a symex command."
+  `(defun ,name ,args
+     ,docstring
+     ,@body
+     (symex-select-nearest)
+     (symex-tidy)))
+
+(defmacro symex-define-insertion-command (name args docstring &rest body)
+  "Define a symex command that enters an insertion state."
+  `(defun ,name ,args
+     ,docstring
+     ,@body
+     (symex-enter-lowest)))
+
 (symex-define-command symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
@@ -86,27 +106,6 @@
   (if tree-sitter-mode
       (symex-ts-replace)
     (symex-lisp-replace)))
-
-;; TODO: `symex-define-command` macro
-;; - write the wrapping code before and after without needing advice
-;; - select-nearest etc. after, and remove the ad hoc cases
-;; - this would also allow more fine-grained handling, e.g. different types of commands
-;; - this would also avoid the need for `symex--evil-repeatable-commands`, so that we could `(evil-add-command-properties fn :repeat t)` directly -- this would also support users defining new symex commands and having them be repeatable without a manual registration process
-
-(defmacro symex-define-command (name args docstring &rest body)
-  "Define a symex command."
-  `(defun ,name ,args
-     ,docstring
-     ,@body
-     (symex-select-nearest)
-     (symex-tidy)))
-
-(defmacro symex-define-insertion-command (name args docstring &rest body)
-  "Define a symex command that enters an insertion state."
-  `(defun ,name ,args
-     ,docstring
-     ,@body
-     (symex-enter-lowest)))
 
 (symex-define-command symex-clear ()
   "Clear contents of symex."
@@ -285,7 +284,6 @@ by default, joins next symex to current one."
       (symex-ts-open-line-before)
     (symex-lisp--open-line-before)))
 
-;; TODO: define the rest as insertion commands
 (symex-define-insertion-command symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -51,6 +51,9 @@
 ;; - select-nearest etc. after, and remove the ad hoc cases
 ;; - this would also allow more fine-grained handling, e.g. different types of commands
 ;; - this would also avoid the need for `symex--evil-repeatable-commands`, so that we could `(evil-add-command-properties fn :repeat t)` directly -- this would also support users defining new symex commands and having them be repeatable without a manual registration process
+;; TODO: dot operator disrupts scroll margins
+;; TODO: why doesn't symex-replace undo in one step?
+;; TODO: maybe identify "non-disorienting" commands and define a new macro for them. E.g. symex-tidy is itself a command. it that bad?
 
 (defmacro symex-define-command (name args docstring &rest body)
   "Define a symex command."
@@ -59,7 +62,7 @@
      ,docstring
      ,@body
      (symex-select-nearest)
-     (symex-tidy)))
+     (symex--tidy)))
 
 (defmacro symex-define-insertion-command (name
                                           args
@@ -90,26 +93,30 @@
       (symex-ts-delete-node-backward count)
     (symex-lisp--delete-backwards count)))
 
-(defun symex-delete-remaining ()
+(symex-define-command symex-delete-remaining ()
   "Delete remaining symexes at this level."
   (interactive)
   (let ((count (symex--remaining-length)))
     (symex-delete count)))
 
-(symex-define-insertion-command symex-change (count)
+(defun symex--change (count)
   "Change COUNT symexes."
-  (interactive "p")
   (if tree-sitter-mode
       (symex-ts-delete-node-forward count t) ; only delete - no tidy
     (symex-lisp--delete count)))
 
-(defun symex-change-remaining ()
+(symex-define-insertion-command symex-change (count)
+  "Change COUNT symexes."
+  (interactive "p")
+  (symex--change count))
+
+(symex-define-insertion-command symex-change-remaining ()
   "Change remaining symexes at this level."
   (interactive)
   (let ((count (symex--remaining-length)))
-    (symex-change count)))
+    (symex--change count)))
 
-(defun symex-replace ()
+(symex-define-insertion-command symex-replace ()
   "Replace contents of symex."
   (interactive)
   (if tree-sitter-mode
@@ -136,7 +143,7 @@
       (re-search-forward lispy-left)
       (symex--go-down))))
 
-(defun symex-emit-backward (count)
+(symex-define-command symex-emit-backward (count)
   "Emit backward, COUNT times."
   (interactive "p")
   (dotimes (_ count)
@@ -154,7 +161,7 @@
       (fixup-whitespace)
       (re-search-backward lispy-left))))
 
-(defun symex-emit-forward (count)
+(symex-define-command symex-emit-forward (count)
   "Emit forward, COUNT times."
   (interactive "p")
   (dotimes (_ count)
@@ -174,12 +181,11 @@
     (fixup-whitespace)
     (symex--go-down)))
 
-(defun symex-capture-backward (count)
+(symex-define-command symex-capture-backward (count)
   "Capture from behind, COUNT times."
   (interactive "p")
   (dotimes (_ count)
-    (symex--capture-backward))
-  (symex-tidy))
+    (symex--capture-backward)))
 
 (defun symex--capture-forward ()
   "Capture from the front."
@@ -190,19 +196,17 @@
         (symex--go-up))  ; need to be inside the symex to emit and capture
       (lispy-forward-slurp-sexp 1))))
 
-(defun symex-capture-forward (count)
+(symex-define-command symex-capture-forward (count)
   "Capture from the front, COUNT times."
   (interactive "p")
   (dotimes (_ count)
     (symex--capture-forward)))
 
-(defun symex-split ()
+(symex-define-command symex-split ()
   "Split symex into two."
   (interactive)
   (paredit-split-sexp)
-  (forward-char)
-  (symex-select-nearest)
-  (symex-tidy))
+  (forward-char))
 
 (defun symex--join ()
   "Merge symexes at the same level."
@@ -210,19 +214,19 @@
     (symex--go-forward)
     (paredit-join-sexps)))
 
-(defun symex-join (count)
+(symex-define-command symex-join (count)
   "Merge COUNT symexes at the same level."
   (interactive "p")
   (dotimes (_ count)
     (symex--join)))
 
-(defun symex-join-lines (count)
+(symex-define-command symex-join-lines (count)
   "Join COUNT lines inside symex."
   (interactive "p")
   (dotimes (_ count)
     (symex--join-lines)))
 
-(defun symex-join-lines-backwards (count)
+(symex-define-command symex-join-lines-backwards (count)
   "Join COUNT lines backwards inside symex."
   (interactive "p")
   (dotimes (_ count)
@@ -244,7 +248,7 @@ by default, joins next symex to current one."
     (save-excursion (forward-sexp)
                     (evil-join (line-beginning-position)
                                (line-end-position))))
-  (symex-tidy))
+  (symex--tidy))
 
 (defun symex-yank (count)
   "Yank (copy) COUNT symexes."
@@ -259,7 +263,7 @@ by default, joins next symex to current one."
   (let ((count (symex--remaining-length)))
     (symex-yank count)))
 
-(defun symex-paste-before (count)
+(symex-define-command symex-paste-before (count)
   "Paste before symex, COUNT times."
   (interactive "p")
   (setq this-command 'evil-paste-before)
@@ -269,7 +273,7 @@ by default, joins next symex to current one."
       (dotimes (_ count)
         (symex-lisp--paste-before)))))
 
-(defun symex-paste-after (count)
+(symex-define-command symex-paste-after (count)
   "Paste after symex, COUNT times."
   (interactive "p")
   (setq this-command 'evil-paste-after)
@@ -321,7 +325,7 @@ by default, joins next symex to current one."
       (symex-ts-insert-at-end)
     (symex-lisp--insert-at-end)))
 
-(defun symex-create (type)
+(defun symex--create (type)
   "Create new symex (list).
 
 New list delimiters are determined by the TYPE."
@@ -333,44 +337,41 @@ New list delimiters are determined by the TYPE."
           ((equal type 'curly)
            (insert "{}"))
           ((equal type 'angled)
-           (insert "<>"))))
-  (symex-tidy))
+           (insert "<>")))))
 
-(defun symex-create-round ()
+(symex-define-command symex-create-round ()
   "Create new symex with round delimiters."
   (interactive)
-  (symex-create 'round))
+  (symex--create 'round))
 
-(defun symex-create-square ()
+(symex-define-command symex-create-square ()
   "Create new symex with square delimiters."
   (interactive)
-  (symex-create 'square))
+  (symex--create 'square))
 
-(defun symex-create-curly ()
+(symex-define-command symex-create-curly ()
   "Create new symex with curly delimiters."
   (interactive)
-  (symex-create 'curly))
+  (symex--create 'curly))
 
-(defun symex-create-angled ()
+(symex-define-command symex-create-angled ()
   "Create new symex with angled delimiters."
   (interactive)
-  (symex-create 'angled))
+  (symex--create 'angled))
 
-(defun symex-insert-newline (count)
+(symex-define-command symex-insert-newline (count)
   "Insert COUNT newlines before symex."
   (interactive "p")
-  (newline-and-indent count)
-  (symex-tidy))
+  (newline-and-indent count))
 
-(defun symex-append-newline (count)
+(symex-define-command symex-append-newline (count)
   "Append COUNT newlines after symex."
   (interactive "p")
   (save-excursion
     (forward-sexp)
-    (newline-and-indent count)
-    (symex-tidy)))
+    (newline-and-indent count)))
 
-(defun symex-swallow ()
+(symex-define-command symex-swallow ()
   "Swallow the head of the symex.
 
 This consumes the head of the symex, putting the rest of its contents
@@ -379,10 +380,9 @@ in the parent symex."
   (save-excursion
     (symex--go-up)
     (symex--go-forward)
-    (paredit-splice-sexp-killing-backward))
-  (symex-tidy))
+    (paredit-splice-sexp-killing-backward)))
 
-(defun symex-swallow-tail ()
+(symex-define-command symex-swallow-tail ()
   "Swallow the tail of the symex.
 
 This consumes the tail of the symex, putting the head
@@ -392,10 +392,9 @@ in the parent symex."
     (symex--go-up)
     (symex--go-forward)
     (paredit-splice-sexp-killing-forward)
-    (symex--go-backward))
-  (symex-tidy))
+    (symex--go-backward)))
 
-(defun symex-splice ()
+(symex-define-command symex-splice ()
   "Splice or 'clip' symex.
 
 If the symex is a nested list, this operation eliminates the symex,
@@ -408,44 +407,44 @@ then no action is taken."
         (symex-delete 1)
       (save-excursion
         (evil-surround-delete (char-after))
-        (symex--go-down)
-        (symex-tidy)))))
+        (symex--go-down)))))
 
-(defun symex-wrap-round ()
+(symex-define-command symex-wrap-round ()
   "Wrap with ()."
   (interactive)
   (paredit-wrap-round)
   (symex--go-down))
 
-(defun symex-wrap-square ()
+(symex-define-command symex-wrap-square ()
   "Wrap with []."
   (interactive)
   (paredit-wrap-square)
   (symex--go-down))
 
-(defun symex-wrap-curly ()
+(symex-define-command symex-wrap-curly ()
   "Wrap with {}."
   (interactive)
   (paredit-wrap-curly)
   (evil-find-char-backward nil 123))
 
-(defun symex-wrap-angled ()
+(symex-define-command symex-wrap-angled ()
   "Wrap with <>."
   (interactive)
   (paredit-wrap-angled)
   (evil-find-char-backward nil 60))
 
-(defun symex-wrap ()
+(symex-define-insertion-command symex-wrap ()
   "Wrap with containing symex."
   (interactive)
   (symex-wrap-round)
-  (symex-insert-at-beginning))
+  (symex--go-up))
 
-(defun symex-wrap-and-append ()
+(symex-define-insertion-command symex-wrap-and-append ()
   "Wrap with containing symex and append."
   (interactive)
   (symex-wrap-round)
-  (symex-insert-at-end))
+  (symex--go-up)
+  (forward-sexp))
 
 (defun symex--shift-forward ()
   "Move symex forward in current tree level."
@@ -457,13 +456,13 @@ then no action is taken."
     (error (backward-sexp)
            nil)))
 
-(defun symex-shift-forward (count)
+(symex-define-command symex-shift-forward (count)
   "Move symex forward COUNT times in current tree level."
   (interactive "p")
   (dotimes (_ count)
     (symex--shift-forward)))
 
-(defun symex-shift-forward-most ()
+(symex-define-command symex-shift-forward-most ()
   "Move symex backward COUNT times in current tree level."
   (interactive)
   (let ((col (current-column))
@@ -485,12 +484,12 @@ then no action is taken."
       (symex--go-backward)
       t)))
 
-(defun symex-shift-backward (count)
+(symex-define-command symex-shift-backward (count)
   "Move symex backward COUNT times in current tree level."
   (interactive "p")
   (dotimes (_ count) (symex--shift-backward)))
 
-(defun symex-shift-backward-most ()
+(symex-define-command symex-shift-backward-most ()
   "Move symex backward COUNT times in current tree level."
   (interactive)
   (let ((col (current-column))
@@ -504,7 +503,7 @@ then no action is taken."
                 (= row (line-number-at-pos)))
       (symex--shift-forward))))
 
-(defun symex-change-delimiter ()
+(symex-define-command symex-change-delimiter ()
   "Change delimiter enclosing current symex, e.g. round -> square brackets."
   (interactive)
   (if (or (lispy-left-p) (symex-string-p))
@@ -512,7 +511,7 @@ then no action is taken."
     (let ((bounds (bounds-of-thing-at-point 'sexp)))
       (evil-surround-region (car bounds) (cdr bounds) 'inclusive 40))))
 
-(defun symex-comment (count)
+(symex-define-command symex-comment (count)
   "Comment out COUNT symexes."
   (interactive "p")
   (if tree-sitter-mode
@@ -521,7 +520,7 @@ then no action is taken."
       (mark-sexp count)
       (comment-dwim nil))))
 
-(defun symex-comment-remaining ()
+(symex-define-command symex-comment-remaining ()
   "Comment out remaining symexes at this level."
   (interactive)
   (let ((count (symex--remaining-length)))
@@ -583,7 +582,7 @@ If INDEX is provided, insert the prefix at INDEX instead of cycling."
           (symex--insert-prefix prefix-list index)
         (symex--insert-prefix prefix-list (1+ deleted-index))))))
 
-(defun symex-cycle-quote (index)
+(symex-define-command symex-cycle-quote (index)
   "Cycle through configured quoting prefixes in `symex-quote-prefix-list`.
 
 If an INDEX is provided, then this replaces the existing prefix (if
@@ -599,10 +598,9 @@ because 0 has a different meaning in symex mode, and is an unusual
 prefix argument to use in Emacs functions.  1-indexed behavior is also
 the more natural choice here in any case."
   (interactive "P")
-  (symex--cycle-prefix symex-quote-prefix-list (and index (1- index)))
-  (symex-tidy))
+  (symex--cycle-prefix symex-quote-prefix-list (and index (1- index))))
 
-(defun symex-cycle-unquote (index)
+(symex-define-command symex-cycle-unquote (index)
   "Cycle through configured quoting prefixes in `symex-unquote-prefix-list`.
 
 If an INDEX is provided, then this replaces the existing prefix (if
@@ -618,43 +616,42 @@ because 0 has a different meaning in symex mode, and is an unusual
 prefix argument to use in Emacs functions.  1-indexed behavior is also
 the more natural choice here in any case."
   (interactive "P")
-  (symex--cycle-prefix symex-unquote-prefix-list (and index (1- index)))
-  (symex-tidy))
+  (symex--cycle-prefix symex-unquote-prefix-list (and index (1- index))))
 
-(defun symex-remove-quoting-level ()
+(symex-define-command symex-remove-quoting-level ()
   "Remove any quoting prefix at point, if present.
 
 This removes either quoting or unquoting prefixes, and removes up to one
 layer of quoting."
   (interactive)
   (symex--delete-prefix (append symex-quote-prefix-list
-                                symex-unquote-prefix-list))
-  (symex-tidy))
+                                symex-unquote-prefix-list)))
 
-(defun symex-add-quoting-level ()
+(symex-define-command symex-add-quoting-level ()
   "Add a quoting level."
   (interactive)
-  (insert "'")
-  (symex-tidy))
+  (insert "'"))
 
-(defun symex-quasiquote ()
+(symex-define-command symex-quasiquote ()
   "Quasiquote symex."
   (interactive)
-  (insert "`")
-  (symex-tidy))
+  (insert "`"))
 
-(defun symex-escape-quote ()
+(symex-define-command symex-escape-quote ()
   "Escape quote in quoted symex."
   (interactive)
-  (insert ",")
-  (symex-tidy))
+  (insert ","))
 
-(defun symex-tidy ()
+(defun symex--tidy ()
   "Auto-indent symex and fix any whitespace."
-  (interactive)
   (if tree-sitter-mode
       (symex-ts-tidy)
     (symex-lisp-tidy)))
+
+(symex-define-command symex-tidy ()
+  "Auto-indent symex and fix any whitespace."
+  (interactive)
+  (symex--tidy))
 
 (cl-defun symex--transform-in-isolation (traversal side-effect &key pre-traversal)
   "Transform a symex in a temporary buffer and replace the original with it.
@@ -693,9 +690,9 @@ effect is not performed during the pre-traversal."
            (error nil))
          (buffer-string)))))
   (save-excursion (yank))
-  (symex-tidy))
+  (symex--tidy))
 
-(defun symex-tidy-proper ()
+(symex-define-command symex-tidy-proper ()
   "Properly tidy things up.
 
 This operates on the subtree indicated by the selection, rather than
@@ -712,10 +709,10 @@ implementation."
   (interactive)
   (symex--transform-in-isolation
    symex--traversal-postorder-in-tree
-   #'symex-tidy
+   #'symex--tidy
    :pre-traversal (symex-traversal (circuit symex--traversal-preorder-in-tree))))
 
-(defun symex-collapse ()
+(symex-define-command symex-collapse ()
   "Collapse a symex to a single line.
 
 This operates on the subtree indicated by the selection, rather than
@@ -737,7 +734,7 @@ implementation."
    (apply-partially #'symex--join-lines t)
    :pre-traversal (symex-traversal (circuit symex--traversal-preorder-in-tree))))
 
-(defun symex-collapse-remaining ()
+(symex-define-command symex-collapse-remaining ()
   "Collapse the remaining symexes to the current line."
   (interactive)
   (save-excursion
@@ -747,7 +744,7 @@ implementation."
                                       (symex--join-lines t)))
                                   (symex-make-move 1 0)))))
 
-(defun symex-unfurl-remaining ()
+(symex-define-command symex-unfurl-remaining ()
   "Unfurl the remaining symexes so they each occupy separate lines."
   (interactive)
   (save-excursion
@@ -758,25 +755,22 @@ implementation."
     (symex--do-while-traversing (apply-partially #'symex-insert-newline 1)
                                 (symex-make-move 1 0))))
 
-(defun symex-tidy-remaining ()
+(symex-define-command symex-tidy-remaining ()
   "Tidy the remaining symexes."
   (interactive)
   (save-excursion
     ;; do it once first since it will be executed as a side-effect
     ;; _after_ each step in the traversal
-    (symex-tidy)
-    (symex--do-while-traversing #'symex-tidy
-                                (symex-make-move 1 0)))
-  ;; not sure why this nearest selection is needed, but eventually we may
-  ;; just want to wrap every command with this at the end anyway, so,
-  ;; in retrospect from that point, this wouldn't hurt
-  (symex-select-nearest))
+    (symex--tidy)
+    (symex--do-while-traversing #'symex--tidy
+                                (symex-make-move 1 0))))
 
-(defun symex-unfurl ()
+(symex-define-command symex-unfurl ()
   "Unfurl the constituent symexes so they each occupy separate lines."
   (interactive)
   (save-excursion
     (symex--go-up)
+    ;; TODO: should this be a private version instead?
     (symex-unfurl-remaining)))
 
 (provide 'symex-transformations)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -116,15 +116,12 @@
      (symex-select-nearest)
      (symex-tidy)))
 
-(defun symex-clear ()
+(symex-define-command symex-clear ()
   "Clear contents of symex."
   (interactive)
   (if tree-sitter-mode
       (symex-ts-clear)
-    (progn
-      (symex--clear)
-      (symex-select-nearest)
-      (symex-tidy))))
+    (symex--clear)))
 
 (defun symex--emit-backward ()
   "Emit backward."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -72,7 +72,7 @@
   (interactive "p")
   (if tree-sitter-mode
       (symex-ts-delete-node-forward count)
-    (symex-lisp--delete count)))
+    (symex-lisp-delete count)))
 
 (symex-define-command symex-delete-backwards (count)
   "Delete COUNT symexes backwards."
@@ -87,12 +87,12 @@
   (let ((count (symex--remaining-length)))
     (symex-delete count)))
 
-(defun symex-change (count)
+(symex-define-insertion-command symex-change (count)
   "Change COUNT symexes."
   (interactive "p")
   (if tree-sitter-mode
-      (symex-ts-change-node-forward count)
-    (symex-lisp--change count)))
+      (symex-ts-delete-node-forward count t) ; only delete - no tidy
+    (symex-lisp--delete count)))
 
 (defun symex-change-remaining ()
   "Change remaining symexes at this level."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -85,10 +85,7 @@
   (interactive)
   (if tree-sitter-mode
       (symex-ts-replace)
-    (progn (symex-lisp-clear)
-           (when (or (symex-form-p) (symex-string-p))
-             (forward-char))
-           (symex-enter-lowest))))
+    (symex-lisp-replace)))
 
 ;; TODO: `symex-define-command` macro
 ;; - write the wrapping code before and after without needing advice

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -279,7 +279,7 @@ by default, joins next symex to current one."
       (symex-ts-open-line-after)
     (symex-lisp--open-line-after)))
 
-(defun symex-open-line-before ()
+(symex-define-insertion-command symex-open-line-before ()
   "Open new line before symex."
   (interactive)
   (if tree-sitter-mode

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -80,24 +80,12 @@
   (let ((count (symex--remaining-length)))
     (symex-change count)))
 
-(defun symex--clear ()
-  "Helper to clear contents of symex."
-  (cond ((symex-opening-round-p)
-         (apply #'evil-delete (evil-inner-paren)))
-        ((symex-opening-square-p)
-         (apply #'evil-delete (evil-inner-bracket)))
-        ((symex-opening-curly-p)
-         (apply #'evil-delete (evil-inner-curly)))
-        ((symex-string-p)
-         (apply #'evil-delete (evil-inner-double-quote)))
-        (t (kill-sexp))))
-
 (defun symex-replace ()
   "Replace contents of symex."
   (interactive)
   (if tree-sitter-mode
       (symex-ts-replace)
-    (progn (symex--clear)
+    (progn (symex-lisp-clear)
            (when (or (symex-form-p) (symex-string-p))
              (forward-char))
            (symex-enter-lowest))))
@@ -121,7 +109,7 @@
   (interactive)
   (if tree-sitter-mode
       (symex-ts-clear)
-    (symex--clear)))
+    (symex-lisp-clear)))
 
 (defun symex--emit-backward ()
   "Emit backward."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -47,14 +47,14 @@
 ;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; TODO: define these using the symex command macro
-(defun symex-delete (count)
+(symex-define-command symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
   (if tree-sitter-mode
       (symex-ts-delete-node-forward count)
     (symex-lisp--delete count)))
 
-(defun symex-delete-backwards (count)
+(symex-define-command symex-delete-backwards (count)
   "Delete COUNT symexes backwards."
   (interactive "p")
   (if tree-sitter-mode

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -61,7 +61,6 @@
       (symex-ts-delete-node-backward count)
     (symex-lisp--delete-backwards count)))
 
-;; TODO: symex-delete-remaining: fix symex--remaining-length for TS
 (defun symex-delete-remaining ()
   "Delete remaining symexes at this level."
   (interactive)
@@ -246,7 +245,6 @@ by default, joins next symex to current one."
     (symex-ts-yank count)
     (symex-lisp--yank count)))
 
-;; TODO: symex-yank-remaining: fix symex--remaining-length for TS
 (defun symex-yank-remaining ()
   "Yank (copy) remaining symexes at this level."
   (interactive)
@@ -288,28 +286,28 @@ by default, joins next symex to current one."
     (symex-lisp--open-line-before)))
 
 ;; TODO: define the rest as insertion commands
-(defun symex-append-after ()
+(symex-define-insertion-command symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)
   (if tree-sitter-mode
       (symex-ts-append-after)
     (symex-lisp--append-after)))
 
-(defun symex-insert-before ()
+(symex-define-insertion-command symex-insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."
   (interactive)
   (if tree-sitter-mode
       (symex-ts-insert-before)
     (symex-lisp--insert-before)))
 
-(defun symex-insert-at-beginning ()
+(symex-define-insertion-command symex-insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
   (if tree-sitter-mode
       (symex-ts-insert-at-beginning)
     (symex-lisp--insert-at-beginning)))
 
-(defun symex-insert-at-end ()
+(symex-define-insertion-command symex-insert-at-end ()
   "Insert at end of symex."
   (interactive)
   (if tree-sitter-mode


### PR DESCRIPTION
### Summary of Changes

This adds a couple of macros for defining symex commands. These macros handle the boilerplate of reindenting after execution, etc. and minimize the use of advice for such things, and could also implicitly include other common functionality like evil-repeat (dot `.`) support which currently requires a separate registration step. In general these macros represent a better abstraction of a command than using functions with ad hoc and inconsistently used set up and tear down code, and should allow us to integrate more easily with other tools like tree-edit. See [this ticket](https://github.com/users/countvajhula/projects/1/views/1?pane=issue&itemId=12134124) for a full description.

**Bugs remaining**:

- [x] paste-before with multiple lines yanked leaves the original line untidy
- [ ] replace (s) in string leaves cursor inside the quotes
- [x] S delimiter with { and } work the same and { doesn't do what it should
- [ ] shift backward/forward most doesn't move the body of the function to defun (probably related to indent level and maybe selection? verify whether it happens on the main branch)
- [ ] capture backward captures beyond current level at head
- [x] when on the last expression, & joins to previous instead of doing nothing
- [x] append newline inserts extra leading whitespace when indented (verify behavior on main) - also note insert newline doesn't do this
- [ ] J within an expression with next expression on same line joins next line instead of NOOP
- [ ] M-J collapse with comments present mangles structure
- [x] C-; evals the next symex not the current one (except if only one)

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
