### PR TITLE
Fix #88: call sly-mrepl instead of sly-repl in symex-repl-common-lisp

### DIFF
--- a/symex-interface-common-lisp.el
+++ b/symex-interface-common-lisp.el
@@ -28,7 +28,7 @@
 (require 'slime      nil 'noerror)
 (require 'slime-repl nil 'noerror)
 (require 'sly        nil 'noerror)
-(require 'sly-repl   nil 'noerror)
+(require 'sly-mrepl  nil 'noerror)
 (require 'symex-interop)
 (require 'symex-custom)
 
@@ -44,7 +44,7 @@
 (declare-function sly-eval-last-expression "ext:sly")
 (declare-function sly-eval-defun           "ext:sly")
 (declare-function sly-eval-buffer          "ext:sly")
-(declare-function sly-repl                 "ext:sly-repl")
+(declare-function sly-mrepl                "ext:sly-mrepl")
 (declare-function sly-eval-print-last-expression "ext:sly")
 (declare-function sly-documentation        "ext:sly")
 

--- a/symex-interface-common-lisp.el
+++ b/symex-interface-common-lisp.el
@@ -95,7 +95,7 @@ Accounts for different point location in evil vs Emacs mode."
   ;; this already goes to the active repl prompt
   ;; so there's no need to move point there
   (if (eq symex-common-lisp-backend 'sly)
-      (sly-repl)
+      (call-interactively #'sly-mrepl)
       (slime-repl))
   (symex-enter-lowest))
 


### PR DESCRIPTION
### Summary of Changes

Closes #88

Call `sly-mrepl` instead of the deprecated `sly-repl` in `symex-repl-common-lisp`.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
