### PR TITLE
Trim dependencies

### DIFF
--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -6,7 +6,7 @@ Symex DSL
 Introduction
 ------------
 
-The Symex.el Emacs package consists of three things: (1) A high-level language (or DSL) for tree operations, (2) A low-level tree abstraction layer, and (3) An Evil modal UI. The modal UI is documented in the `README <https://github.com/drym-org/symex.el/blob/master/README.rst>`_, and the low-level abstraction layer is fulfilled by third party packages like Paredit and Lispy. This is the documentation for the DSL.
+The Symex.el Emacs package consists of three things: (1) A high-level language (or DSL) for tree operations, (2) A low-level tree abstraction layer, and (3) An Evil modal UI. The modal UI is documented in the `README <https://github.com/drym-org/symex.el/blob/master/README.rst>`_, and the low-level abstraction layer is fulfilled by third party packages like Paredit and Tree-Sitter. This is the documentation for the DSL.
 
 The Symex DSL allows you to specify arbitrary tree traversals in a cursor-oriented manner. That is, instead of describing traversals from an absolute reference point such as a root node, it allows you to describe traversals from the first-person vantage point of the cursor -- what would you do if you were where this cursor is right now? It allows you to describe what you'd like to do in intuitive terms that make sense for movement in a tree. Symex is the language a squirrel might use to describe a traversal to another squirrel.
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint+less:
 	@$(MAKE) -f $(THIS_FILE) lint 2>&1 | less
 
 lint-no-noise:
-	@$(MAKE) -f $(THIS_FILE) lint 2>&1 | grep -v "start with.*prefix" |grep -v "lexical-binding" |grep -v "non-snapshot.*racket" |grep -v "non-snapshot.*clever" |grep -v "Version.*header is missing" |grep -v "Package-Version"
+	@$(MAKE) -f $(THIS_FILE) lint 2>&1 | grep -v "start with.*prefix" |grep -v "lexical-binding" |grep -v "non-snapshot.*racket" |grep -v "Version.*header is missing" |grep -v "Package-Version"
 
 lint-noiseless:
 	@$(MAKE) -f $(THIS_FILE) lint-no-noise 2>&1 | less

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Symex (pronounced sym-ex, as in symbolic expression) is a modal (like Vim but si
 - Implementing new structure-related features in general is easy [1]_.
 - Keybindings are short and memorable
 
-At the moment, symex mode uses ``paredit`` and ``lispy`` to provide much of its low level functionality. In the future, this layer of primitives may be replaced with a layer that explicitly uses the abstract syntax tree, for still greater precision.
+At the moment, symex mode uses ``paredit`` to provide much of its low level functionality. In the future, this layer of primitives may be replaced with a layer that explicitly uses the abstract syntax tree, for still greater precision.
 
 As of Jan 2023, there is "alpha" support for non-Lisp languages via ``tree-sitter``. While motions and a couple of basic transformations should work across languages (i.e. not only Lisp), it should be considered an early preview rather than production-worthy. Full support is planned for completion by March 20, 2023.
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Symex (pronounced sym-ex, as in symbolic expression) is a modal (like Vim but si
 - Implementing new structure-related features in general is easy [1]_.
 - Keybindings are short and memorable
 
-At the moment, symex mode uses ``paredit`` to provide much of its low level functionality. In the future, this layer of primitives may be replaced with a layer that explicitly uses the abstract syntax tree, for still greater precision.
+Under the hood, Symex mode uses ``paredit`` and Tree-Sitter for parsing the code syntax tree.
 
 As of Jan 2023, there is "alpha" support for non-Lisp languages via ``tree-sitter``. While motions and a couple of basic transformations should work across languages (i.e. not only Lisp), it should be considered an early preview rather than production-worthy. Full support is planned for completion by March 20, 2023.
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Symex (pronounced sym-ex, as in symbolic expression) is a modal (like Vim but si
 - Implementing new structure-related features in general is easy [1]_.
 - Keybindings are short and memorable
 
-At the moment, symex mode uses ``paredit``, ``lispy``, and `evil-cleverparens <https://github.com/luxbock/evil-cleverparens>`_ to provide much of its low level functionality. In the future, this layer of primitives may be replaced with a layer that explicitly uses the abstract syntax tree, for still greater precision.
+At the moment, symex mode uses ``paredit`` and ``lispy`` to provide much of its low level functionality. In the future, this layer of primitives may be replaced with a layer that explicitly uses the abstract syntax tree, for still greater precision.
 
 As of Jan 2023, there is "alpha" support for non-Lisp languages via ``tree-sitter``. While motions and a couple of basic transformations should work across languages (i.e. not only Lisp), it should be considered an early preview rather than production-worthy. Full support is planned for completion by March 20, 2023.
 

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -26,7 +26,6 @@
 ;;; Code:
 
 
-(require 'lispy)
 (require 'evil)
 (require 'symex-primitives)
 (require 'symex-evaluator)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -30,7 +30,6 @@
 ;;; Code:
 
 
-(require 'lispy)
 (require 'paredit)
 (require 'symex-data)
 
@@ -46,7 +45,7 @@
               (symex-lisp--point-at-start-p)
               (looking-back "[,'`]" (line-beginning-position))
               (save-excursion (backward-char)  ; just inside symex
-                              (or (lispy-left-p)
+                              (or (symex-left-p)
                                   (symex-string-p))))
     (condition-case nil
         (backward-sexp)
@@ -104,16 +103,32 @@
 (defun symex-lisp--point-at-start-p ()
   "Check if point is at the start of a symex."
   (and (not (eolp))
-       (not (looking-at-p lispy-right))
-       (or (lispy-left-p)                           ; |(*
+       (not (looking-at-p symex--re-right))
+       (or (symex-left-p)                           ; |(*
            (symex--special-left-p)                  ; |'(*
            ;; looking at the start of any non-whitespace:
            (and (not (looking-at-p "[[:space:]]"))
                 (or (bolp)                          ; ^|.
                     (looking-back "[[:space:]]"     ; _|.
                                   (line-beginning-position))
-                    (looking-back lispy-left        ; (*|.
+                    (looking-back symex--re-left    ; (*|.
                                   (line-beginning-position)))))))
+
+(defun symex-lisp--point-at-end-p ()
+  "Check if point is at the end of a symex."
+  (condition-case nil
+      (save-excursion
+        (forward-char)
+        (symex-right-p))
+    (error nil)))
+
+;; From Lispy
+(defvar symex--re-left "[([{]"
+  "Opening delimiter.")
+
+;; From Lispy
+(defvar symex--re-right "[])}]"
+  "Closing delimiter.")
 
 (defvar symex--re-comment-line "^[[:space:]]*;"
   "A comment line.")
@@ -131,28 +146,45 @@
   "A line that isn't blank and isn't a comment line.")
 
 (defvar symex--re-racket-syntax-object
-  (concat "#['`]" lispy-left))
+  (concat "#['`]" symex--re-left))
 
 (defvar symex--re-splicing-unquote
-  (concat ",@" lispy-left))
+  (concat ",@" symex--re-left))
 
 (defvar symex--re-racket-unquote-syntax
-  (concat "#," lispy-left))
+  (concat "#," symex--re-left))
 
 (defvar symex--re-racket-splicing-unsyntax
-  (concat "#,@" lispy-left))
+  (concat "#,@" symex--re-left))
 
 (defvar symex--re-quoted-list
-  (concat "['`]" lispy-left))
+  (concat "['`]" symex--re-left))
 
 (defvar symex--re-unquoted-list
-  (concat "," lispy-left))
+  (concat "," symex--re-left))
 
 (defvar symex--re-clojure-deref-reader-macro
-  (concat "@" lispy-left))
+  (concat "@" symex--re-left))
 
 (defvar symex--re-clojure-literal-lambda
-  (concat "#" lispy-left))
+  (concat "#" symex--re-left))
+
+;; based on lispy-left-p
+(defun symex-left-p ()
+  "Check if we're at (i.e. after) an opening delimiter."
+  (looking-at symex--re-left))
+
+;; based on lispy-right-p
+(defun symex-right-p ()
+  "Check if we're at (i.e. after) a closing delimiter."
+  (looking-back symex--re-right
+                (line-beginning-position)))
+
+;; From https://www.gnu.org/software/emacs/manual/html_node/efaq/Matching-parentheses.html
+(defun symex-other ()
+  "Move point to the other delimiter in a matching pair."
+  (cond ((looking-at "\\s(") (forward-list 1) (backward-char 1))
+        ((looking-at "\\s)") (forward-char 1) (backward-list 1))))
 
 (defun symex-comment-line-p ()
   "Check if we're currently at the start of a comment line."
@@ -183,9 +215,9 @@
 (defun symex-empty-list-p ()
   "Check if we're looking at an empty list."
   (looking-at-p
-   (concat lispy-left
+   (concat symex--re-left
            symex--re-whitespace
-           lispy-right)))
+           symex--re-right)))
 
 (defun symex-empty-string-p ()
   "Check if we're looking at an empty list."
@@ -268,24 +300,24 @@ as special cases here."
   (or (save-excursion
         (and (symex--racket-splicing-unsyntax-p)
              (progn (forward-char 4)
-                    (looking-at-p (concat symex--re-whitespace lispy-right)))))
+                    (looking-at-p (concat symex--re-whitespace symex--re-right)))))
       (save-excursion
         (and (or (symex--racket-syntax-object-p)
                  (symex--racket-unquote-syntax-p)
                  (symex--splicing-unquote-p))
              (progn (forward-char 3)
-                    (looking-at-p (concat symex--re-whitespace lispy-right)))))
+                    (looking-at-p (concat symex--re-whitespace symex--re-right)))))
       (save-excursion
         (and (or (symex--quoted-list-p)
                  (symex--unquoted-list-p)
                  (symex--clojure-deref-reader-macro-p)
                  (symex--clojure-literal-lambda-p))
              (progn (forward-char 2)
-                    (looking-at-p (concat symex--re-whitespace lispy-right)))))))
+                    (looking-at-p (concat symex--re-whitespace symex--re-right)))))))
 
 (defun symex-atom-p ()
   "Check if the symex is an atom."
-  (not (lispy-left-p)))
+  (not (symex-left-p)))
 
 (defun symex-form-p ()
   "Check if the symex is a composite expression, i.e. a nonatom."
@@ -311,9 +343,9 @@ as special cases here."
 (defun symex-lisp-select-nearest ()
   "Select the appropriate symex nearest to point."
   (cond ((and (not (eobp))
-              (save-excursion (forward-char) (lispy-right-p))) ; |)
+              (save-excursion (forward-char) (symex-right-p))) ; |)
          (forward-char)
-         (lispy-different))
+         (symex-other))
         ((thing-at-point 'sexp)       ; som|ething
          (beginning-of-thing 'sexp))
         (t (symex-lisp--if-stuck (symex-lisp--backward)
@@ -473,7 +505,7 @@ If the current character is non-whitespace, point is not moved."
     (if (or (symex-empty-list-p)
             (symex--special-empty-list-p))
         (setq result 0)
-      (cond ((lispy-left-p) (forward-char))
+      (cond ((symex-left-p) (forward-char))
             ;; note that at least some symex features would benefit by
             ;; treating these special cases as "symex-left-p" but it
             ;; would likely be too much special case handling to be

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -30,7 +30,6 @@
 (require 'lispy)
 (require 'evil)
 (require 'evil-surround)
-(require 'evil-cleverparens)  ;; really only need cp-textobjects here
 (require 'symex-primitives)
 (require 'symex-primitives-lisp)
 (require 'symex-utils)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -27,7 +27,6 @@
 
 (require 'cl-lib)
 
-(require 'lispy)
 (require 'evil)
 (require 'evil-surround)
 (require 'symex-primitives)
@@ -98,12 +97,12 @@
            ;; don't leave an empty line where the symex was
            (kill-whole-line)))
         ((or (save-excursion (evil-last-non-blank) ; (<>$
-                             (lispy-left-p)))
+                             (symex-left-p)))
          (symex--join-to-next))
         ((looking-at-p "\n") (symex--go-backward)) ; (abc <>
         ((save-excursion (back-to-indentation) ; ^<>)
                          (forward-char)
-                         (lispy-right-p))
+                         (symex-right-p))
          ;; Cases 2 and 3 in issue #18
          ;; if the deleted symex is preceded by a comment line
          ;; or if the preceding symex is followed by a comment
@@ -120,10 +119,10 @@
                              (progn (evil-find-char 1 ?\;)
                                     t)
                            (error nil))
-                   (symex--join-to-match lispy-right)
+                   (symex--join-to-match symex--re-right)
                    (symex--adjust-point)))))))
         ((save-excursion (forward-char) ; ... <>)
-                         (lispy-right-p))
+                         (symex-right-p))
          (symex--go-backward))
         (t (symex--go-forward))))
 
@@ -158,7 +157,7 @@
   (evil-move-end-of-line)
   (unless (or (symex--current-line-empty-p)
               (save-excursion (backward-char)
-                              (lispy-left-p)))
+                              (symex-left-p)))
     (insert " ")))
 
 (defun symex-lisp-insert-before ()
@@ -170,14 +169,14 @@
 (defun symex-lisp-insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
-  (when (or (lispy-left-p)
+  (when (or (symex-left-p)
             (symex-string-p))
     (forward-char)))
 
 (defun symex-lisp-insert-at-end ()
   "Insert at end of symex."
   (interactive)
-  (if (or (lispy-left-p)
+  (if (or (symex-left-p)
           (symex-string-p))
       (progn (forward-sexp)
              (backward-char))

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -35,7 +35,6 @@
 (require 'lispy)
 (require 'evil)
 (require 'evil-surround)
-(require 'evil-cleverparens)  ;; really only need cp-textobjects here
 (require 'symex-primitives)
 (require 'symex-primitives-lisp)
 (require 'symex-utils)

--- a/symex.el
+++ b/symex.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/drym-org/symex.el
 ;; Version: 1.0
-;; Package-Requires: ((emacs "25.1") (tsc "0.15.2") (tree-sitter "0.15.2") (lispy "0.26.0") (paredit "24") (evil-cleverparens "20170718.413") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
+;; Package-Requires: ((emacs "25.1") (tsc "0.15.2") (tree-sitter "0.15.2") (lispy "0.26.0") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -34,10 +34,10 @@
 ;; can be described using an expressive DSL, and invoked in a vim-
 ;; style modal interface.
 ;;
-;; At the moment, symex mode uses paredit, lispy, and evil-cleverparens
-;; to provide much of its low level functionality.
-;; In the future, this layer of primitives may be replaced with a layer
-;; that explicitly uses the abstract syntax tree, for greater precision.
+;; At the moment, symex mode uses paredit and lispy to provide much of
+;; its low level functionality.  In the future, this layer of primitives
+;; may be replaced with a layer that explicitly uses the abstract syntax
+;; tree, for greater precision.
 
 ;;; Code:
 

--- a/symex.el
+++ b/symex.el
@@ -34,10 +34,8 @@
 ;; can be described using an expressive DSL, and invoked in a vim-
 ;; style modal interface.
 ;;
-;; At the moment, symex mode uses paredit to provide much of its low
-;; level functionality.  In the future, this layer of primitives may
-;; be replaced with a layer that explicitly uses the abstract syntax
-;; tree, for greater precision.
+;; Under the hood, Symex mode uses paredit and Tree-Sitter for parsing
+;; the code syntax tree.
 
 ;;; Code:
 

--- a/symex.el
+++ b/symex.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/drym-org/symex.el
 ;; Version: 1.0
-;; Package-Requires: ((emacs "25.1") (tsc "0.15.2") (tree-sitter "0.15.2") (lispy "0.26.0") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
+;; Package-Requires: ((emacs "25.1") (tsc "0.15.2") (tree-sitter "0.15.2") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -34,14 +34,12 @@
 ;; can be described using an expressive DSL, and invoked in a vim-
 ;; style modal interface.
 ;;
-;; At the moment, symex mode uses paredit and lispy to provide much of
-;; its low level functionality.  In the future, this layer of primitives
-;; may be replaced with a layer that explicitly uses the abstract syntax
+;; At the moment, symex mode uses paredit to provide much of its low
+;; level functionality.  In the future, this layer of primitives may
+;; be replaced with a layer that explicitly uses the abstract syntax
 ;; tree, for greater precision.
 
 ;;; Code:
-
-(require 'lispy)
 
 (require 'symex-evil)
 (require 'symex-interop)


### PR DESCRIPTION
### Summary of Changes

Trim dependencies to minimize package footprint and also prepare for decomposing the package (#26 ), making it/them more portable and lean.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
