### PR TITLE
Replace calls to obsolete point-at-bol and point-at-eol

### DIFF
--- a/symex-utils-ts.el
+++ b/symex-utils-ts.el
@@ -28,7 +28,10 @@
 (defun symex-ts--delete-current-line-if-empty (point)
   "Delete the line containing POINT if it is empty."
   (save-excursion (goto-char point)
-                  (when (string-match "^[[:space:]]*$" (buffer-substring-no-properties (point-at-bol) (point-at-eol)))
+                  (when (string-match "^[[:space:]]*$"
+                                      (buffer-substring-no-properties
+                                        (line-beginning-position)
+                                        (line-end-position)))
                     (kill-whole-line)
                     (pop kill-ring)
                     (setq kill-ring-yank-pointer kill-ring)


### PR DESCRIPTION
### Summary of Changes

Replace calls to `point-at-bol` and `point-at-eol`. These functions are obsolete since Emacs 29.1.

### Public Domain Dedication

- [X] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
