### PR TITLE
Patch to exclude Clojure from tree-sitter handling on Emacs 29

### DIFF
--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -35,6 +35,16 @@
 
 (defvar symex-clojure-modes)
 
+(defun symex-tree-sitter-p ()
+  "Whether to use the tree sitter primitives."
+  (and tree-sitter-mode
+       ;; We use the Lisp primitives for Clojure
+       ;; even though Emacs 29 provides tree-sitter APIs
+       ;; for it, since the Lisp primitives in Symex are
+       ;; more mature than the Tree Sitter ones at the
+       ;; present time.
+       (not (member major-mode symex-clojure-modes))))
+
 ;;; User Interface
 
 (defun symex--adjust-point ()
@@ -193,16 +203,6 @@ symexes, returns the end point of the last one found."
       (symex-ts-set-current-node-from-point)
     (symex-lisp--select-nearest))
   (point))
-
-(defun symex-tree-sitter-p ()
-  "Whether to use the tree sitter primitives."
-  (and tree-sitter-mode
-       ;; We use the Lisp primitives for Clojure
-       ;; even though Emacs 29 provides tree-sitter APIs
-       ;; for it, since the Lisp primitives in Symex are
-       ;; more mature than the Tree Sitter ones at the
-       ;; present time.
-       (not (member major-mode symex-clojure-modes))))
 
 (defun symex--primitive-exit ()
   "Take necessary actions as part of exiting Symex mode, at a primitive level."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -87,7 +87,7 @@ selected according to the ranges that have changed."
 
 (defun symex-ts-comment (&optional count)
   "Comment out COUNT expressions."
-  (when tree-sitter-mode
+  (when (symex-tree-sitter-p)
     (let* ((count (or count 1))
            (node (symex-ts-get-current-node))
            (start-pos (tsc-node-start-position node))

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -49,14 +49,14 @@
 (defun symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-delete-node-forward count)
     (symex-lisp--delete count)))
 
 (defun symex-delete-backwards (count)
   "Delete COUNT symexes backwards."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-delete-node-backward count)
     (symex-lisp--delete-backwards count)))
 
@@ -70,7 +70,7 @@
 (defun symex-change (count)
   "Change COUNT symexes."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-change-node-forward count)
     (symex-lisp--change count)))
 
@@ -95,7 +95,7 @@
 (defun symex-replace ()
   "Replace contents of symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-replace)
     (progn (symex--clear)
            (when (or (symex-form-p) (symex-string-p))
@@ -105,7 +105,7 @@
 (defun symex-clear ()
   "Clear contents of symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-clear)
     (progn
       (symex--clear)
@@ -238,7 +238,7 @@ by default, joins next symex to current one."
 (defun symex-yank (count)
   "Yank (copy) COUNT symexes."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
     (symex-ts-yank count)
     (symex-lisp--yank count)))
 
@@ -253,7 +253,7 @@ by default, joins next symex to current one."
   "Paste before symex, COUNT times."
   (interactive "p")
   (setq this-command 'evil-paste-before)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-paste-before count)
     (symex--with-undo-collapse
       (dotimes (_ count)
@@ -263,7 +263,7 @@ by default, joins next symex to current one."
   "Paste after symex, COUNT times."
   (interactive "p")
   (setq this-command 'evil-paste-after)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-paste-after count)
     (symex--with-undo-collapse
       (dotimes (_ count)
@@ -272,42 +272,42 @@ by default, joins next symex to current one."
 (defun symex-open-line-after ()
   "Open new line after symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-open-line-after)
     (symex-lisp--open-line-after)))
 
 (defun symex-open-line-before ()
   "Open new line before symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-open-line-before)
     (symex-lisp--open-line-before)))
 
 (defun symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-append-after)
     (symex-lisp--append-after)))
 
 (defun symex-insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-insert-before)
     (symex-lisp--insert-before)))
 
 (defun symex-insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-insert-at-beginning)
     (symex-lisp--insert-at-beginning)))
 
 (defun symex-insert-at-end ()
   "Insert at end of symex."
   (interactive)
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-insert-at-end)
     (symex-lisp--insert-at-end)))
 
@@ -505,7 +505,7 @@ then no action is taken."
 (defun symex-comment (count)
   "Comment out COUNT symexes."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-tree-sitter-p)
       (symex-ts-comment count)
     (progn
       (mark-sexp count)


### PR DESCRIPTION
### Summary of Changes

As Emacs 29 ships with Tree Sitter support, which appears to include the Clojure language, Symex uses the tree sitter primitives for Clojure instead of the Lisp primitives which are more mature. This is likely leading to a degraded user experience for such users since Tree Sitter support in Symex is still at an alpha stage. This PR is a quick patch to handle Clojure as a Lisp language instead of as a Tree Sitter language.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
