### PR TITLE
Ability to do transformations in the DSL

### DIFF
--- a/DSL-Docs.rst
+++ b/DSL-Docs.rst
@@ -112,8 +112,8 @@ Examples
 
   (symex-execute-traversal
     (symex-traversal
-      (maneuver (maneuver (move up)
-                          (circuit (move forward)))
+      (maneuver (move up)
+                (circuit (move forward))
                 (move up))))
 
 venture

--- a/symex-data.el
+++ b/symex-data.el
@@ -348,6 +348,7 @@ This is the traversal that will be chosen if the condition is false."
              (nth 0 obj))
     (error nil)))
 
+;; TODO: eliminate count since we can use circuit
 (defun symex--deletion-count (deletion)
   "Get the count component of a DELETION."
   (nth 1 deletion))
@@ -363,6 +364,17 @@ This is the traversal that will be chosen if the condition is false."
   "Get the side component of a PASTE."
   (nth 1 paste))
 
+(defun symex-operation-p (obj)
+  "Check if OBJ specifies a generic operation."
+  (condition-case nil
+      (equal 'operation
+             (nth 0 obj))
+    (error nil)))
+
+(defun symex--operation-operation (operation)
+  "Get the actual OPERATION to perform."
+  (nth 1 operation))
+
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)
@@ -372,7 +384,10 @@ This is the traversal that will be chosen if the condition is false."
       (symex-detour-p obj)
       (symex-precaution-p obj)
       (symex-protocol-p obj)
-      (symex-decision-p obj)))
+      (symex-decision-p obj)
+      (symex-delete-p obj)
+      (symex-paste-p obj)
+      (symex-operation-p obj)))
 
 
 (provide 'symex-data)

--- a/symex-data.el
+++ b/symex-data.el
@@ -348,9 +348,8 @@ This is the traversal that will be chosen if the condition is false."
              (nth 0 obj))
     (error nil)))
 
-;; TODO: eliminate count since we can use circuit
-(defun symex--deletion-count (deletion)
-  "Get the count component of a DELETION."
+(defun symex--deletion-what (deletion)
+  "Get the 'what' component of a DELETION."
   (nth 1 deletion))
 
 (defun symex-paste-p (obj)

--- a/symex-data.el
+++ b/symex-data.el
@@ -341,6 +341,28 @@ This is the traversal that will be chosen if the condition is false."
              (nth 0 obj))
     (error nil)))
 
+(defun symex-delete-p (obj)
+  "Check if OBJ specifies a deletion."
+  (condition-case nil
+      (equal 'delete
+             (nth 0 obj))
+    (error nil)))
+
+(defun symex--deletion-count (deletion)
+  "Get the count component of a DELETION."
+  (nth 1 deletion))
+
+(defun symex-paste-p (obj)
+  "Check if OBJ specifies a paste."
+  (condition-case nil
+      (equal 'paste
+             (nth 0 obj))
+    (error nil)))
+
+(defun symex--paste-side (paste)
+  "Get the side component of a PASTE."
+  (nth 1 paste))
+
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
   (or (symex-move-p obj)

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -185,6 +185,18 @@ forward, backward, up, or down."
         ((equal 'down direction)
          '(symex-make-move 0 -1))))
 
+(defmacro symex--compile-delete (count)
+  "Compile a deletion from Symex -> Lisp.
+
+COUNT - the number symexes to delete."
+  `'(delete ,count))
+
+(defmacro symex--compile-paste (side)
+  "Compile a paste from Symex -> Lisp.
+
+SIDE - the side to paste on, either before or after."
+  `'(paste ,side))
+
 ;; TODO: support args here like lambda / defun (i.e. as a list in the
 ;; binding form -- not passed in but syntactically inserted)
 ;; try a lambda / defun with args to see what I mean
@@ -216,6 +228,10 @@ a detour, a move, etc., which is specified using the Symex DSL."
          `(symex--compile-decision ,@(cdr traversal)))
         ((equal 'move (car traversal))
          `(symex--compile-move ,@(cdr traversal)))
+        ((equal 'delete (car traversal))
+         `(symex--compile-delete ,@(cdr traversal)))
+        ((equal 'paste (car traversal))
+         `(symex--compile-paste ,@(cdr traversal)))
         (t traversal)))  ; function-valued symbols wind up here
 
 (defmacro symex-deftraversal (name traversal &optional docstring)

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -185,11 +185,12 @@ forward, backward, up, or down."
         ((equal 'down direction)
          '(symex-make-move 0 -1))))
 
-(defmacro symex--compile-delete (count)
+(defmacro symex--compile-delete (&optional what)
   "Compile a deletion from Symex -> Lisp.
 
-COUNT - the number symexes to delete."
-  `'(delete ,count))
+WHAT - what to delete, either this, previous, next, remaining or until."
+  (let ((what (or what 'this)))
+    `'(delete ,what)))
 
 (defmacro symex--compile-paste (side)
   "Compile a paste from Symex -> Lisp.

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -162,12 +162,18 @@ Evaluates to a COMPUTATION on the traversal actually executed."
               (> times 0))
       (let ((result (symex-execute-traversal traversal
                                              computation)))
-        (when result
-          (let ((executed-remaining-circuit
-                 (symex-execute-traversal remaining-circuit
-                                          computation)))
-            (symex--compute-results result
-                                    executed-remaining-circuit
+        (if result
+            (let ((executed-remaining-circuit
+                   (symex-execute-traversal remaining-circuit
+                                            computation)))
+              (symex--compute-results result
+                                      executed-remaining-circuit
+                                      computation))
+          (when (not times)
+            ;; if looping indefinitely, then count 0
+            ;; times executed as success
+            (symex--compute-results symex--move-zero
+                                    nil
                                     computation)))))))
 
 (defun symex-execute-detour (detour computation)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -272,6 +272,17 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                 nil
                                 computation)))))
 
+(defun symex-execute-operation (operation computation)
+  "Attempt to execute a given OPERATION.
+
+Evaluates to a COMPUTATION on the traversal actually executed."
+  (let ((op (symex--operation-operation operation)))
+    (funcall op)
+    ;; TODO: compute based on an appropriate result here
+    (symex--compute-results symex--move-zero
+                            nil
+                            computation)))
+
 (defun symex--execute-traversal (traversal computation)
   "Helper to execute TRAVERSAL and perform COMPUTATION."
   (cond ((symex-maneuver-p traversal)
@@ -304,6 +315,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         ((symex-paste-p traversal)
          (symex-execute-paste traversal
                               computation))
+        ((symex-operation-p traversal)
+         (symex-execute-operation traversal
+                                  computation))
         (t (funcall traversal))))
 
 (defun symex-execute-traversal (traversal &optional computation side-effect)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -69,26 +69,6 @@ Optional argument COMPUTATION currently unused."
     (when executed-move
       (list executed-move))))
 
-(cl-defun symex-go-forward (&optional (count 1))
-  "Move forward COUNT symexes."
-  (interactive)
-  (symex--execute-tree-move (symex-make-move count 0)))
-
-(cl-defun symex-go-backward (&optional (count 1))
-  "Move backward COUNT symexes."
-  (interactive)
-  (symex--execute-tree-move (symex-make-move (- count) 0)))
-
-(cl-defun symex-go-up (&optional (count 1))
-  "Move up COUNT symexes."
-  (interactive)
-  (symex--execute-tree-move (symex-make-move 0 count)))
-
-(cl-defun symex-go-down (&optional (count 1))
-  "Move down COUNT symexes."
-  (interactive)
-  (symex--execute-tree-move (symex-make-move 0 (- count))))
-
 (defun symex--compute-results (a b computation)
   "Combine component computed results A and B into an aggregate result.
 

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -231,8 +231,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
   "Attempt to execute a given DELETION.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (let ((count (symex--deletion-count deletion)))
-    (symex-delete count)
+  (let ((what (symex--deletion-what deletion)))
+    ;; TODO: "what" is currently ignored
+    (symex-delete 1)
     ;; TODO: compute based on an appropriate result here
     (symex--compute-results symex--move-zero
                             nil

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -241,6 +241,34 @@ Evaluates to a COMPUTATION on the traversal actually executed."
       (symex-execute-traversal alternative
                                computation))))
 
+(defun symex--execute-traversal (traversal computation)
+  "Helper to execute TRAVERSAL and perform COMPUTATION."
+  (cond ((symex-maneuver-p traversal)
+         (symex-execute-maneuver traversal
+                                 computation))
+        ((symex-venture-p traversal)
+         (symex-execute-venture traversal
+                                computation))
+        ((symex-circuit-p traversal)
+         (symex-execute-circuit traversal
+                                computation))
+        ((symex-protocol-p traversal)
+         (symex-execute-protocol traversal
+                                 computation))
+        ((symex-precaution-p traversal)
+         (symex-execute-precaution traversal
+                                   computation))
+        ((symex-detour-p traversal)
+         (symex-execute-detour traversal
+                               computation))
+        ((symex-decision-p traversal)
+         (symex-execute-decision traversal
+                                 computation))
+        ((symex-move-p traversal)
+         (symex-execute-move traversal
+                             computation))
+        (t (funcall traversal))))
+
 (defun symex-execute-traversal (traversal &optional computation side-effect)
   "Execute a tree TRAVERSAL.
 
@@ -261,31 +289,8 @@ Evaluates to a COMPUTATION on the traversal actually executed."
     (let ((original-location (point))
           (original-point-height-offset
            (symex--point-height-offset))
-          (executed-traversal (cond ((symex-maneuver-p traversal)
-                                     (symex-execute-maneuver traversal
-                                                             computation))
-                                    ((symex-venture-p traversal)
-                                     (symex-execute-venture traversal
-                                                            computation))
-                                    ((symex-circuit-p traversal)
-                                     (symex-execute-circuit traversal
-                                                            computation))
-                                    ((symex-protocol-p traversal)
-                                     (symex-execute-protocol traversal
-                                                             computation))
-                                    ((symex-precaution-p traversal)
-                                     (symex-execute-precaution traversal
-                                                               computation))
-                                    ((symex-detour-p traversal)
-                                     (symex-execute-detour traversal
-                                                           computation))
-                                    ((symex-decision-p traversal)
-                                     (symex-execute-decision traversal
-                                                             computation))
-                                    ((symex-move-p traversal)
-                                     (symex-execute-move traversal
-                                                         computation))
-                                    (t (funcall traversal)))))
+          (executed-traversal (symex--execute-traversal traversal
+                                                        computation)))
       (let ((result (funcall (symex--computation-perceive computation)
                              executed-traversal)))
         (if result

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -244,9 +244,10 @@ Evaluates to a COMPUTATION on the traversal actually executed."
 
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((side (symex--paste-side paste)))
-    (let ((result (if (eq 'before side)
-                      (symex-paste-before 1)
-                    (symex-paste-after 1))))
+    (let ((result (save-excursion
+                    (if (eq 'before side)
+                        (symex-paste-before 1)
+                      (symex-paste-after 1)))))
       ;; TODO: compute based on an appropriate result here
       (when result
         (symex--compute-results symex--move-zero

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -246,16 +246,25 @@ Evaluates to a COMPUTATION on the traversal actually executed."
 
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((count (symex--deletion-count deletion)))
-    (symex-delete count)))
+    (symex-delete count)
+    ;; TODO: compute based on an appropriate result here
+    (symex--compute-results symex--move-zero
+                            nil
+                            computation)))
 
 (defun symex-execute-paste (paste computation)
   "Attempt to execute a given PASTE.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((side (symex--paste-side paste)))
-    (if (eq 'before side)
-        (symex-paste-before count)
-      (symex-paste-after count))))
+    (let ((result (if (eq 'before side)
+                      (symex-paste-before 1)
+                    (symex-paste-after 1))))
+      ;; TODO: compute based on an appropriate result here
+      (when result
+        (symex--compute-results symex--move-zero
+                                nil
+                                computation)))))
 
 (defun symex--execute-traversal (traversal computation)
   "Helper to execute TRAVERSAL and perform COMPUTATION."

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -96,8 +96,8 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                                      computation)))
         (when executed-phase
           (let ((executed-remaining-phases
-                 (symex-execute-traversal remaining-maneuver
-                                          computation)))
+                 (symex-execute-maneuver remaining-maneuver
+                                         computation)))
             (when executed-remaining-phases
               (symex--compute-results executed-phase
                                       (if (equal executed-remaining-phases
@@ -123,8 +123,8 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                                      computation)))
         (when executed-phase
           (let ((executed-remaining-phases
-                 (symex-execute-traversal remaining-venture
-                                          computation)))
+                 (symex-execute-venture remaining-venture
+                                        computation)))
             (symex--compute-results executed-phase
                                     executed-remaining-phases
                                     computation)))))))
@@ -144,8 +144,8 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                              computation)))
         (if result
             (let ((executed-remaining-circuit
-                   (symex-execute-traversal remaining-circuit
-                                            computation)))
+                   (symex-execute-circuit remaining-circuit
+                                          computation)))
               (symex--compute-results result
                                       executed-remaining-circuit
                                       computation))
@@ -208,8 +208,8 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                                       computation)))
         (if executed-option
             executed-option
-          (symex-execute-traversal remaining-protocol
-                                   computation))))))
+          (symex-execute-protocol remaining-protocol
+                                  computation))))))
 
 (defun symex-execute-decision (decision computation)
   "Attempt to execute a given DECISION.

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -244,9 +244,12 @@ Evaluates to a COMPUTATION on the traversal actually executed."
 
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((side (symex--paste-side paste)))
-    (let ((result (save-excursion
-                    (if (eq 'before side)
-                        (symex-paste-before 1)
+    (let ((result (if (eq 'before side)
+                      ;; TODO: ensure point invariance
+                      ;; at the command level
+                      (progn (symex-paste-before 1)
+                             (symex--go-forward))
+                    (save-excursion
                       (symex-paste-after 1)))))
       ;; TODO: compute based on an appropriate result here
       (when result

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -233,11 +233,12 @@ Evaluates to a COMPUTATION on the traversal actually executed."
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((what (symex--deletion-what deletion)))
     ;; TODO: "what" is currently ignored
-    (symex-delete 1)
-    ;; TODO: compute based on an appropriate result here
-    (symex--compute-results symex--move-zero
-                            nil
-                            computation)))
+    (let ((result (symex-delete 1)))
+      ;; TODO: compute based on an appropriate result here
+      (when result
+        (symex--compute-results symex--move-zero
+                                nil
+                                computation)))))
 
 (defun symex-execute-paste (paste computation)
   "Attempt to execute a given PASTE.

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -241,6 +241,22 @@ Evaluates to a COMPUTATION on the traversal actually executed."
       (symex-execute-traversal alternative
                                computation))))
 
+(defun symex-execute-deletion (deletion computation)
+  "Attempt to execute a given DELETION.
+
+Evaluates to a COMPUTATION on the traversal actually executed."
+  (let ((count (symex--deletion-count deletion)))
+    (symex-delete count)))
+
+(defun symex-execute-paste (paste computation)
+  "Attempt to execute a given PASTE.
+
+Evaluates to a COMPUTATION on the traversal actually executed."
+  (let ((side (symex--paste-side paste)))
+    (if (eq 'before side)
+        (symex-paste-before count)
+      (symex-paste-after count))))
+
 (defun symex--execute-traversal (traversal computation)
   "Helper to execute TRAVERSAL and perform COMPUTATION."
   (cond ((symex-maneuver-p traversal)
@@ -267,6 +283,12 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         ((symex-move-p traversal)
          (symex-execute-move traversal
                              computation))
+        ((symex-delete-p traversal)
+         (symex-execute-deletion traversal
+                                 computation))
+        ((symex-paste-p traversal)
+         (symex-execute-paste traversal
+                              computation))
         (t (funcall traversal))))
 
 (defun symex-execute-traversal (traversal &optional computation side-effect)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -248,8 +248,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
     (let ((result (if (eq 'before side)
                       ;; TODO: ensure point invariance
                       ;; at the command level
-                      (progn (symex-paste-before 1)
-                             (symex--go-forward))
+                      (let ((result (symex-paste-before 1)))
+                        (symex--go-forward)
+                        result)
                     (save-excursion
                       (symex-paste-after 1)))))
       ;; TODO: compute based on an appropriate result here
@@ -333,6 +334,10 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         (if result
             (progn (funcall side-effect)
                    result)
+          ;; TODO: simply returning to the original location
+          ;; isn't enough when the traversal might include
+          ;; transformations. It may be necessary to execute
+          ;; traversals in a temporary buffer.
           (goto-char original-location)
           (symex-select-nearest)
           (let* ((current-point-height-offset (symex--point-height-offset))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -131,9 +131,7 @@
 (defun symex-lisp--point-at-end-p ()
   "Check if point is at the end of a symex."
   (condition-case nil
-      (save-excursion
-        (forward-char)
-        (symex-right-p))
+      (symex-right-p)
     (error nil)))
 
 ;; From Lispy
@@ -191,8 +189,7 @@
 ;; based on lispy-right-p
 (defun symex-right-p ()
   "Check if we're at (i.e. after) a closing delimiter."
-  (looking-back symex--re-right
-                (line-beginning-position)))
+  (looking-at symex--re-right))
 
 ;; From https://www.gnu.org/software/emacs/manual/html_node/efaq/Matching-parentheses.html
 (defun symex-other ()
@@ -357,7 +354,7 @@ as special cases here."
 (defun symex-lisp-select-nearest ()
   "Select the appropriate symex nearest to point."
   (cond ((and (not (eobp))
-              (save-excursion (forward-char) (symex-right-p))) ; |)
+              (symex-right-p)) ; |)
          (symex-other))
         ((thing-at-point 'sexp)       ; som|ething
          (beginning-of-thing 'sexp))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -518,28 +518,30 @@ If the current character is non-whitespace, point is not moved."
 (defun symex-lisp--go-up-by-one ()
   "Go up one level."
   (let ((result 1))
-    (if (or (symex-empty-list-p)
-            (symex--special-empty-list-p))
-        (setq result 0)
-      (cond ((symex-left-p) (forward-char))
-            ;; note that at least some symex features would benefit by
-            ;; treating these special cases as "symex-left-p" but it
-            ;; would likely be too much special case handling to be
-            ;; worth it to support those cases naively, without an AST
-            ((or (symex--racket-syntax-object-p)
-                 (symex--splicing-unquote-p)
-                 (symex--racket-unquote-syntax-p))
-             (forward-char 3))
-            ((symex--racket-splicing-unsyntax-p)
-             (forward-char 4))
-            ((or (symex--quoted-list-p)
-                 (symex--unquoted-list-p)
-                 (symex--clojure-deref-reader-macro-p)
-                 (symex--clojure-literal-lambda-p))
-             (forward-char 2))
-            (t (setq result 0)))
-      ;; find first non-whitespace character
-      (symex-lisp--go-to-next-non-whitespace-char))
+    ;; TODO: this should enter at the primitive / command level
+    ;; but perhaps not at the user level
+    (cond ((or (symex-empty-list-p)
+               (symex--special-empty-list-p))
+           (forward-char (symex--form-offset)))
+          ((symex-left-p) (forward-char))
+          ;; note that at least some symex features would benefit by
+          ;; treating these special cases as "symex-left-p" but it
+          ;; would likely be too much special case handling to be
+          ;; worth it to support those cases naively, without an AST
+          ((or (symex--racket-syntax-object-p)
+               (symex--splicing-unquote-p)
+               (symex--racket-unquote-syntax-p))
+           (forward-char 3))
+          ((symex--racket-splicing-unsyntax-p)
+           (forward-char 4))
+          ((or (symex--quoted-list-p)
+               (symex--unquoted-list-p)
+               (symex--clojure-deref-reader-macro-p)
+               (symex--clojure-literal-lambda-p))
+           (forward-char 2))
+          (t (setq result 0)))
+    ;; find first non-whitespace character
+    (symex-lisp--go-to-next-non-whitespace-char)
     result))
 
 (defun symex-lisp--go-up (&optional count)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -353,7 +353,13 @@ as special cases here."
 
 (defun symex-lisp-select-nearest ()
   "Select the appropriate symex nearest to point."
-  (cond ((and (not (eobp))
+  (cond ((and (not (bobp))
+              (save-excursion (backward-char)
+                              (symex-left-p))
+              (not (eobp))
+              (symex-right-p)) ; (|)
+         nil) ; don't change level in selection
+        ((and (not (eobp))
               (symex-right-p)) ; |)
          (symex-other))
         ((thing-at-point 'sexp)       ; som|ething

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -311,6 +311,13 @@ text, on the respective side."
                       (length pasted-text))) ; end of pasted text
         (symex--same-line-tidy-affected))
       ;; move to indicate appropriate posterior selection
+      ;; TODO: this should probably be at the "user" level
+      ;; suggesting there should be 4 levels rather than 3:
+      ;; 0. primitives
+      ;; 1. tractable, deterministic symex commands
+      ;; 2. DSL over those primitives and commands
+      ;; 3. user commands that use the DSL and include UX specifics like which expression
+      ;;    should be selected after the fact, and configurable things
       (forward-sexp)
       (forward-char))))
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -304,7 +304,8 @@ text, on the respective side."
           (symex--goto-line end-line)
           ;; if the last line has any trailing forms,
           ;; indent them.
-          (symex--same-line-tidy-affected))))))
+          (symex--same-line-tidy-affected)
+          (not (equal pasted-text "")))))))
 
 (defun symex-lisp--paste-after ()
   "Paste after symex."
@@ -336,7 +337,8 @@ text, on the respective side."
       ;; 3. user commands that use the DSL and include UX specifics like which expression
       ;;    should be selected after the fact, and configurable things
       (forward-sexp)
-      (forward-char))))
+      (forward-char)
+      (not (equal pasted-text "")))))
 
 (defun symex-lisp-yank (count)
   "Yank (copy) COUNT symexes."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -54,8 +54,10 @@
     (error nil))
   (let ((start (point))
         (end (save-excursion
-               (dotimes (_ count)
-                 (forward-sexp))
+               (condition-case nil
+                   (dotimes (_ count)
+                     (forward-sexp))
+                 (error nil))
                (point))))
     (indent-region start end))
   (symex-lisp-select-nearest))

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -80,58 +80,62 @@
   (let ((last-command nil)  ; see symex-yank re: last-command
         (start (point))
         (end (symex--get-end-point count)))
-    (kill-region start end)))
+    (when (> end start)
+      (kill-region start end)
+      t)))
 
 (defun symex-lisp-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
-  (symex-lisp--delete count)
-  (cond ((symex--current-line-empty-p)         ; ^<>$
-         ;; only join up to the next symex if the context suggests
-         ;; that a line break is not desired
-         (if (or (save-excursion (forward-line)
-                                 (not (symex--current-line-empty-p)))
-                 (save-excursion (previous-line)
-                                 (symex--current-line-empty-p)))
-             (symex--join-to-next)
-           ;; don't leave an empty line where the symex was
-           (delete-region (line-beginning-position)
+  (let ((result (symex-lisp--delete count)))
+    (cond ((symex--current-line-empty-p)         ; ^<>$
+           ;; only join up to the next symex if the context suggests
+           ;; that a line break is not desired
+           (if (or (save-excursion (forward-line)
+                                   (not (symex--current-line-empty-p)))
+                   (save-excursion (forward-line -1)
+                                   (symex--current-line-empty-p)))
+               (symex--join-to-next)
+             ;; don't leave an empty line where the symex was
+             (delete-region (line-beginning-position)
                           (1+ (line-end-position)))))
-        ((or (save-excursion (evil-last-non-blank) ; (<>$
-                             (symex-left-p)))
-         (symex--join-to-next))
-        ((looking-at-p "\n")  ; (abc <>
-         (if (save-excursion (forward-line)
-                             (not (symex--current-line-empty-p)))
-             ;; only join up to the next symex if the context suggests
-             ;; that a line break is not desired
-             (symex--join-to-next)
-           (symex--go-backward)))
-        ((save-excursion (back-to-indentation) ; ^<>)
-                         (forward-char)
-                         (symex-right-p))
-         ;; Cases 2 and 3 in issue #18
-         ;; if the deleted symex is preceded by a comment line
-         ;; or if the preceding symex is followed by a comment
-         ;; on the same line, then don't attempt to join lines
-         (let ((original-position (point)))
-           (when (symex--go-backward)
-             (save-excursion
-               (let ((previous-symex-end-pos (symex--get-end-point 1)))
-                 (unless (symex--intervening-comment-line-p previous-symex-end-pos
-                                                            original-position)
-                   (goto-char previous-symex-end-pos)
-                   ;; ensure that there isn't a comment on the
-                   ;; preceding line before joining lines
-                   (unless (condition-case nil
-                               (progn (evil-find-char 1 ?\;)
-                                      t)
-                             (error nil))
-                     (symex--join-to-match symex--re-right))))))))
-        ((save-excursion (forward-char) ; ... <>)
-                         (symex-right-p))
-         (symex--go-backward))
-        (t (symex--go-forward))))
+          ((or (save-excursion (evil-last-non-blank) ; (<>$
+                               (symex-left-p)))
+           (symex--join-to-next))
+          ((looking-at-p "\n")  ; (abc <>
+           (if (save-excursion (forward-line)
+                               (not (symex--current-line-empty-p)))
+               ;; only join up to the next symex if the context suggests
+               ;; that a line break is not desired
+               (symex--join-to-next)
+             (symex--go-backward)))
+          ((save-excursion (back-to-indentation) ; ^<>)
+                           (forward-char)
+                           (symex-right-p))
+           ;; Cases 2 and 3 in issue #18
+           ;; if the deleted symex is preceded by a comment line
+           ;; or if the preceding symex is followed by a comment
+           ;; on the same line, then don't attempt to join lines
+           (let ((original-position (point)))
+             (when (symex--go-backward)
+               (save-excursion
+                 (let ((previous-symex-end-pos (symex--get-end-point 1)))
+                   (unless (symex--intervening-comment-line-p previous-symex-end-pos
+                                                              original-position)
+                     (goto-char previous-symex-end-pos)
+                     ;; ensure that there isn't a comment on the
+                     ;; preceding line before joining lines
+                     (unless (condition-case nil
+                                 (progn (evil-find-char 1 ?\;)
+                                        t)
+                               (error nil))
+                       (symex--join-to-match symex--re-right))))))))
+          ((save-excursion (forward-char) ; ... <>)
+                           (symex-right-p))
+           (symex--go-backward))
+          (t (symex--go-forward)))
+    ;; should we return the actual motion we took?
+    result))
 
 (defun symex-lisp-delete-backwards (count)
   "Delete COUNT symexes backwards."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -163,7 +163,7 @@
   "Open new line before symex."
   (interactive)
   (newline-and-indent)
-  (evil-previous-line)
+  (forward-line -1)
   (indent-according-to-mode)
   (evil-move-end-of-line)
   (unless (or (symex--current-line-empty-p)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -193,22 +193,6 @@
              (backward-char))
     (forward-sexp)))
 
-(defvar symex--traversal-emit-forward
-  (symex-traversal
-   (maneuver (move up)
-             (circuit (move forward))
-             (delete 1) ; probably just delete or "cut" w/ no parens or count
-             (move down)
-             ;; maybe plant/graft/place/put/attach
-             ;; but first get it to work
-             (paste after)))
-  "Emit forward.")
-
-(defun symex-lisp-emit-forward (count)
-  "Emit forward."
-  (dotimes (_ count)
-    (symex-execute-traversal symex--traversal-emit-forward)))
-
 (defun symex-lisp--paste (before after)
   "Paste before, padding on either side.
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -189,6 +189,23 @@
              (backward-char))
     (forward-sexp)))
 
+(defun symex--emit-forward ()
+  "Emit forward."
+  (when (and (symex-left-p)
+             (not (symex-empty-list-p)))
+    (save-excursion
+      (symex--go-up)  ; need to be inside the symex to emit and capture
+      (paredit-forward-barf-sexp 1))
+    (when (symex-empty-list-p)
+      (symex--go-forward)
+      (fixup-whitespace)
+      (re-search-backward symex--re-left))))
+
+(defun symex-lisp-emit-forward (count)
+  "Emit forward."
+  (dotimes (_ count)
+    (symex--emit-forward)))
+
 (defun symex-lisp--paste (before after)
   "Paste before, padding on either side.
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -86,56 +86,61 @@
       (kill-region start end)
       t)))
 
+(defun symex-lisp--reset-after-delete ()
+  "Tidy after deletion and select the appropriate symex."
+  (cond ((symex--current-line-empty-p) ; ^<>$
+         ;; only join up to the next symex if the context suggests
+         ;; that a line break is not desired
+         (if (or (save-excursion (forward-line)
+                                 (not (symex--current-line-empty-p)))
+                 (save-excursion (forward-line -1)
+                                 (symex--current-line-empty-p)))
+             (symex--join-to-next)
+           ;; don't leave an empty line where the symex was
+           (delete-region (line-beginning-position)
+                          (1+ (line-end-position)))))
+        ((or (save-excursion (evil-last-non-blank) ; (<>$
+                             (symex-left-p)))
+         (symex--join-to-next))
+        ((looking-at-p "\n")         ; (abc <>
+         (if (save-excursion (forward-line)
+                             (not (symex--current-line-empty-p)))
+             ;; only join up to the next symex if the context suggests
+             ;; that a line break is not desired
+             (symex--join-to-next)
+           (symex--go-backward)))
+        ((save-excursion (back-to-indentation) ; ^<>)
+                         (symex-right-p))
+         ;; Cases 2 and 3 in issue #18
+         ;; if the deleted symex is preceded by a comment line
+         ;; or if the preceding symex is followed by a comment
+         ;; on the same line, then don't attempt to join lines
+         (let ((original-position (point)))
+           (when (symex--go-backward)
+             (save-excursion
+               (let ((previous-symex-end-pos (symex--get-end-point 1)))
+                 (unless (symex--intervening-comment-line-p previous-symex-end-pos
+                                                            original-position)
+                   (goto-char previous-symex-end-pos)
+                   ;; ensure that there isn't a comment on the
+                   ;; preceding line before joining lines
+                   (unless (condition-case nil
+                               (progn (evil-find-char 1 ?\;)
+                                      t)
+                             (error nil))
+                     (symex--join-to-match symex--re-right))))))))
+        ((symex-right-p)             ; ... <>)
+         (symex--go-backward))
+        (t (symex--go-forward))))
+
 (defun symex-lisp-delete (count)
   "Delete COUNT symexes."
   (interactive "p")
   (let ((result (symex-lisp--delete count)))
-    (cond ((symex--current-line-empty-p)         ; ^<>$
-           ;; only join up to the next symex if the context suggests
-           ;; that a line break is not desired
-           (if (or (save-excursion (forward-line)
-                                   (not (symex--current-line-empty-p)))
-                   (save-excursion (forward-line -1)
-                                   (symex--current-line-empty-p)))
-               (symex--join-to-next)
-             ;; don't leave an empty line where the symex was
-             (delete-region (line-beginning-position)
-                          (1+ (line-end-position)))))
-          ((or (save-excursion (evil-last-non-blank) ; (<>$
-                               (symex-left-p)))
-           (symex--join-to-next))
-          ((looking-at-p "\n")  ; (abc <>
-           (if (save-excursion (forward-line)
-                               (not (symex--current-line-empty-p)))
-               ;; only join up to the next symex if the context suggests
-               ;; that a line break is not desired
-               (symex--join-to-next)
-             (symex--go-backward)))
-          ((save-excursion (back-to-indentation) ; ^<>)
-                           (symex-right-p))
-           ;; Cases 2 and 3 in issue #18
-           ;; if the deleted symex is preceded by a comment line
-           ;; or if the preceding symex is followed by a comment
-           ;; on the same line, then don't attempt to join lines
-           (let ((original-position (point)))
-             (when (symex--go-backward)
-               (save-excursion
-                 (let ((previous-symex-end-pos (symex--get-end-point 1)))
-                   (unless (symex--intervening-comment-line-p previous-symex-end-pos
-                                                              original-position)
-                     (goto-char previous-symex-end-pos)
-                     ;; ensure that there isn't a comment on the
-                     ;; preceding line before joining lines
-                     (unless (condition-case nil
-                                 (progn (evil-find-char 1 ?\;)
-                                        t)
-                               (error nil))
-                       (symex--join-to-match symex--re-right))))))))
-          ((symex-right-p) ; ... <>)
-           (symex--go-backward))
-          (t (symex--go-forward)))
-    ;; should we return the actual motion we took?
-    result))
+    (when result
+      (symex-lisp--reset-after-delete)
+      ;; should we return the actual motion we took?
+      result)))
 
 (defun symex-lisp-delete-backwards (count)
   "Delete COUNT symexes backwards."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -112,7 +112,6 @@
                (symex--join-to-next)
              (symex--go-backward)))
           ((save-excursion (back-to-indentation) ; ^<>)
-                           (forward-char)
                            (symex-right-p))
            ;; Cases 2 and 3 in issue #18
            ;; if the deleted symex is preceded by a comment line
@@ -132,8 +131,7 @@
                                         t)
                                (error nil))
                        (symex--join-to-match symex--re-right))))))))
-          ((save-excursion (forward-char) ; ... <>)
-                           (symex-right-p))
+          ((symex-right-p) ; ... <>)
            (symex--go-backward))
           (t (symex--go-forward)))
     ;; should we return the actual motion we took?

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -193,22 +193,21 @@
              (backward-char))
     (forward-sexp)))
 
-(defun symex--emit-forward ()
-  "Emit forward."
-  (when (and (symex-left-p)
-             (not (symex-empty-list-p)))
-    (save-excursion
-      (symex--go-up)  ; need to be inside the symex to emit and capture
-      (paredit-forward-barf-sexp 1))
-    (when (symex-empty-list-p)
-      (symex--go-forward)
-      (fixup-whitespace)
-      (re-search-backward symex--re-left))))
+(defvar symex--traversal-emit-forward
+  (symex-traversal
+   (maneuver (move up)
+             (circuit (move forward))
+             (delete 1) ; probably just delete or "cut" w/ no parens or count
+             (move down)
+             ;; maybe plant/graft/place/put/attach
+             ;; but first get it to work
+             (paste after)))
+  "Emit forward.")
 
 (defun symex-lisp-emit-forward (count)
   "Emit forward."
   (dotimes (_ count)
-    (symex--emit-forward)))
+    (symex-execute-traversal symex--traversal-emit-forward)))
 
 (defun symex-lisp--paste (before after)
   "Paste before, padding on either side.

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -186,7 +186,7 @@ alias for inserting at the end."
   (when (symex-ts-get-current-node)
     (goto-char (tsc-node-start-position (symex-ts-get-current-node)))
     (newline-and-indent)
-    (evil-previous-line)
+    (forward-line -1)
     (indent-according-to-mode)
     (move-end-of-line 1)))
 

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -190,6 +190,10 @@ alias for inserting at the end."
     (indent-according-to-mode)
     (move-end-of-line 1)))
 
+(defun symex-ts-emit-forward (count)
+  "Emit forward"
+  nil)
+
 (defun symex-ts--paste (count direction)
   "Paste before or after symex, COUNT times, according to DIRECTION.
 

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -146,12 +146,24 @@
   (dotimes (_ count)
     (symex--emit-backward)))
 
+(defvar symex--traversal-emit-forward
+  (symex-traversal
+   (maneuver (move up)
+             (circuit (move forward))
+             (delete)
+             (move down)
+             (paste after)))
+  "Emit forward.")
+
+(defun symex--emit-forward (count)
+  "Emit forward."
+  (dotimes (_ count)
+    (symex-execute-traversal symex--traversal-emit-forward)))
+
 (symex-define-command symex-emit-forward (count)
   "Emit forward, COUNT times."
   (interactive "p")
-  (if tree-sitter-mode
-      (symex-ts-emit-forward count)
-    (symex-lisp-emit-forward count)))
+  (symex--emit-forward count))
 
 (defun symex--capture-backward ()
   "Capture from behind."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -76,6 +76,7 @@
      ,@body
      (symex-enter-lowest)))
 
+;; TODO: the return value is lost in the macro
 (symex-define-command symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -140,11 +140,23 @@
       (re-search-forward symex--re-left)
       (symex--go-down))))
 
+(defvar symex--traversal-emit-backward
+  (symex-traversal
+   (maneuver (move up)
+             (delete)
+             (move down)
+             (paste before)))
+  "Emit backward.")
+
+(defun symex--emit-backward (count)
+  "Emit backward."
+  (dotimes (_ count)
+    (symex-execute-traversal symex--traversal-emit-backward)))
+
 (symex-define-command symex-emit-backward (count)
   "Emit backward, COUNT times."
   (interactive "p")
-  (dotimes (_ count)
-    (symex--emit-backward)))
+  (symex--emit-backward count))
 
 (defvar symex--traversal-emit-forward
   (symex-traversal

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -52,14 +52,22 @@
 ;; TODO: dot operator disrupts scroll margins
 ;; TODO: maybe identify "non-disorienting" commands and define a new macro for them. E.g. symex-tidy is itself a command. it that bad?
 
-(defmacro symex-define-command (name args docstring &rest body)
+(defmacro symex-define-command (name
+                                args
+                                docstring
+                                interactive-decl
+                                &rest
+                                body)
   "Define a symex command."
   (declare (indent defun))
-  `(defun ,name ,args
-     ,docstring
-     ,@body
-     (symex-select-nearest)
-     (symex--tidy 1)))
+  (let ((result (gensym)))
+    `(defun ,name ,args
+       ,docstring
+       ,interactive-decl
+       (let ((,result (progn ,@body)))
+         (symex-select-nearest)
+         (symex--tidy 1)
+         ,result))))
 
 (defmacro symex-define-insertion-command (name
                                           args
@@ -76,7 +84,6 @@
      ,@body
      (symex-enter-lowest)))
 
-;; TODO: the return value is lost in the macro
 (symex-define-command symex-delete (count)
   "Delete COUNT symexes."
   (interactive "p")

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -146,23 +146,12 @@
   (dotimes (_ count)
     (symex--emit-backward)))
 
-(defun symex--emit-forward ()
-  "Emit forward."
-  (when (and (symex-left-p)
-             (not (symex-empty-list-p)))
-    (save-excursion
-      (symex--go-up)  ; need to be inside the symex to emit and capture
-      (paredit-forward-barf-sexp 1))
-    (when (symex-empty-list-p)
-      (symex--go-forward)
-      (fixup-whitespace)
-      (re-search-backward symex--re-left))))
-
 (symex-define-command symex-emit-forward (count)
   "Emit forward, COUNT times."
   (interactive "p")
-  (dotimes (_ count)
-    (symex--emit-forward)))
+  (if tree-sitter-mode
+      (symex-ts-emit-forward count)
+    (symex-lisp-emit-forward count)))
 
 (defun symex--capture-backward ()
   "Capture from behind."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -177,26 +177,24 @@
   (interactive "p")
   (symex--emit-forward count))
 
-(defun symex--capture-backward ()
+(defvar symex--traversal-capture-backward
+  (symex-traversal
+   (maneuver (move backward)
+             (delete)
+             (move up)
+             (paste before)
+             (move down)))
+  "Capture backward.")
+
+(defun symex--capture-backward (count)
   "Capture from behind."
-  (when (and (symex-left-p)
-             ;; paredit captures 1 ((|2 3)) -> (1 (2 3)) but we don't
-             ;; want to in this case since point indicates the inner
-             ;; symex, which cannot capture, rather than the outer
-             ;; one. We avoid this by employing a guard condition here.
-             (not (symex--point-at-first-symex-p)))
-    (if (symex-empty-list-p)
-        (forward-char)
-      (symex--go-up))  ; need to be inside the symex to emit and capture
-    (paredit-backward-slurp-sexp 1)
-    (fixup-whitespace)
-    (symex--go-down)))
+  (dotimes (_ count)
+    (symex-execute-traversal symex--traversal-capture-backward)))
 
 (symex-define-command symex-capture-backward (count)
   "Capture from behind, COUNT times."
   (interactive "p")
-  (dotimes (_ count)
-    (symex--capture-backward)))
+  (symex--capture-backward count))
 
 (defun symex--capture-forward ()
   "Capture from the front."

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -35,6 +35,38 @@
 ;;; TRAVERSALS ;;;
 ;;;;;;;;;;;;;;;;;;
 
+(defun symex-go-forward (count)
+  "Move forward COUNT symexes."
+  (interactive "p")
+  ;; TODO: these should be compiled
+  ;; so that the actual executed traversal
+  ;; is (move N 0) rather than
+  ;; (move 1 0) executed N times
+  (symex-execute-traversal
+   (symex-traversal (circuit (move forward)
+                             count))))
+
+(defun symex-go-backward (count)
+  "Move backward COUNT symexes."
+  (interactive "p")
+  (symex-execute-traversal
+   (symex-traversal (circuit (move backward)
+                             count))))
+
+(defun symex-go-up (count)
+  "Move up COUNT symexes."
+  (interactive "p")
+  (symex-execute-traversal
+   (symex-traversal (circuit (move up)
+                             count))))
+
+(defun symex-go-down (count)
+  "Move down COUNT symexes."
+  (interactive "p")
+  (symex-execute-traversal
+   (symex-traversal (circuit (move down)
+                             count))))
+
 (symex-deftraversal symex--traversal-goto-first
   (circuit (move backward))
   "Go to first symex on the present branch.")


### PR DESCRIPTION
### Summary of Changes

Currently, the Symex DSL only has support for motions. We can perform transformations as side effects in traversals (via e.g. `symex--do-while-traversing`) but these side effects are performed at every step of the traversal and cannot be made more fine-grained. This PR adds support for performing arbitrary operations that may be specified in a traversal program at desired points in the traversal. In addition to such general support, it also adds "native" support for core primitives like delete and paste, using which it should be possible to implement a lot of other Symex transformations like emit and capture.

An advantage of doing this now is that, if the DSL uses only a few primitives to implement a large number of features, then we can reuse a lot of this work for Tree Sitter languages as well, as the implementation at the Symex level would be the same and we would just need to tweak a few general primitives (like delete and paste) and fine-tune the contracts between the primitive layer and the DSL layer in order to get the desired behavior, as opposed to tweaking a lot of different specialized functions like emit and capture that may develop specialized bugs.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
