### PR TITLE
Side effect form

### DIFF
--- a/symex-computations.el
+++ b/symex-computations.el
@@ -149,13 +149,6 @@ INPUT - the input."
   (symex-make-computation :perceive #'symex--type-list
                           :act #'append))
 
-(defun symex--side-effect-noop (&rest args)
-  "A null side-effect, i.e. which does nothing.
-
-Any arguments ARGS passed in are ignored."
-  (interactive)
-  (ignore args))
-
 (defun symex--traversal-account (obj)
   "Represents the result OBJ of a traversal as a traversal."
   (cond ((symex-traversal-p obj)

--- a/symex-data.el
+++ b/symex-data.el
@@ -363,16 +363,29 @@ This is the traversal that will be chosen if the condition is false."
   "Get the side component of a PASTE."
   (nth 1 paste))
 
-(defun symex-operation-p (obj)
-  "Check if OBJ specifies a generic operation."
+(defun symex-make-effect (traversal effect)
+  "A specification to perform a side-effect after executing a traversal.
+
+Execute TRAVERSAL and, if it succeeds, execute EFFECT disregarding its
+result (as long as it's successful)."
+  (list 'effect
+        traversal
+        effect))
+
+(defun symex-effect-p (obj)
+  "Check if OBJ specifies a traversal with a side effect."
   (condition-case nil
-      (equal 'operation
+      (equal 'effect
              (nth 0 obj))
     (error nil)))
 
-(defun symex--operation-operation (operation)
-  "Get the actual OPERATION to perform."
-  (nth 1 operation))
+(defun symex--effect-traversal (effect)
+  "Get the traversal to perform with an EFFECT."
+  (nth 1 effect))
+
+(defun symex--effect-effect (effect)
+  "Get the EFFECT to perform as part of traversal execution."
+  (nth 2 effect))
 
 (defun symex-traversal-p (obj)
   "Check if OBJ specifies a traversal."
@@ -386,7 +399,7 @@ This is the traversal that will be chosen if the condition is false."
       (symex-decision-p obj)
       (symex-delete-p obj)
       (symex-paste-p obj)
-      (symex-operation-p obj)))
+      (symex-effect-p obj)))
 
 
 (provide 'symex-data)

--- a/symex-data.el
+++ b/symex-data.el
@@ -367,7 +367,7 @@ This is the traversal that will be chosen if the condition is false."
   "A specification to perform a side-effect after executing a traversal.
 
 Execute TRAVERSAL and, if it succeeds, execute EFFECT disregarding its
-result (as long as it's successful)."
+result."
   (list 'effect
         traversal
         effect))

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -220,6 +220,7 @@ a variable, or use the `symex-deftraversal` form (analogous to `defun`).
 
 TRAVERSAL could be any traversal specification, e.g. a maneuver,
 a detour, a move, etc., which is specified using the Symex DSL."
+  (declare (indent 0))
   (cond ((not (listp traversal)) traversal)  ; e.g. a variable containing a traversal
         ((equal 'protocol (car traversal))
          `(symex--compile-protocol ,@(cdr traversal)))

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -198,6 +198,14 @@ WHAT - what to delete, either this, previous, next, remaining or until."
 SIDE - the side to paste on, either before or after."
   `'(paste ,side))
 
+(defmacro symex--compile-effect (traversal side-effect)
+  "Compile an effect from Symex -> Lisp.
+
+TRAVERSAL - the traversal to perform. This could be any traversal.
+SIDE-EFFECT - the side effect to perform. This is any Lisp expression."
+  `(symex-make-effect (symex-traversal ,traversal)
+                      (lambda () ,side-effect)))
+
 ;; TODO: support args here like lambda / defun (i.e. as a list in the
 ;; binding form -- not passed in but syntactically inserted)
 ;; try a lambda / defun with args to see what I mean
@@ -233,6 +241,8 @@ a detour, a move, etc., which is specified using the Symex DSL."
          `(symex--compile-delete ,@(cdr traversal)))
         ((equal 'paste (car traversal))
          `(symex--compile-paste ,@(cdr traversal)))
+        ((equal 'effect (car traversal))
+         `(symex--compile-effect ,@(cdr traversal)))
         ;; TODO: instead of an implicit escape, it may be better
         ;; to use an explicit one like (esc ...) or (lisp ...)
         (t traversal)))  ; function-valued symbols wind up here

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -198,13 +198,13 @@ WHAT - what to delete, either this, previous, next, remaining or until."
 SIDE - the side to paste on, either before or after."
   `'(paste ,side))
 
-(defmacro symex--compile-effect (traversal side-effect)
+(defmacro symex--compile-effect (traversal effect)
   "Compile an effect from Symex -> Lisp.
 
 TRAVERSAL - the traversal to perform. This could be any traversal.
-SIDE-EFFECT - the side effect to perform. This is any Lisp expression."
+EFFECT - the side effect to perform. This is any Lisp expression."
   `(symex-make-effect (symex-traversal ,traversal)
-                      (lambda () ,side-effect)))
+                      (lambda () ,effect)))
 
 ;; TODO: support args here like lambda / defun (i.e. as a list in the
 ;; binding form -- not passed in but syntactically inserted)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -314,23 +314,17 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                computation))
         (t (funcall traversal))))
 
-(defun symex-execute-traversal (traversal &optional computation side-effect)
+(defun symex-execute-traversal (traversal &optional computation)
   "Execute a tree TRAVERSAL.
 
 TRAVERSAL could be a move, a maneuver, or any other Symex traversal.
 If it is not a Symex expression, then it is assumed to be an ELisp
 function, and the rule for interpretation is to apply the function.
 
-SIDE-EFFECT is the operation to perform as part of the traversal
-\(none by default).
-
 Evaluates to a COMPUTATION on the traversal actually executed."
   (let ((computation (if computation
                          computation
-                       symex--computation-default))
-        (side-effect (if side-effect
-                         side-effect
-                       #'symex--side-effect-noop)))
+                       symex--computation-default)))
     ;; TODO: a macro similar to `symex-save-excursion`
     ;; where it conditionally returns to the original
     ;; point / node depending on whether BODY succeeds
@@ -343,8 +337,7 @@ Evaluates to a COMPUTATION on the traversal actually executed."
       (let ((result (funcall (symex--computation-perceive computation)
                              executed-traversal)))
         (if result
-            (progn (funcall side-effect)
-                   result)
+            result
           ;; TODO: simply returning to the original location
           ;; isn't enough when the traversal might include
           ;; transformations. It may be necessary to execute

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -273,10 +273,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                                        computation)))
       (when executed-traversal
         (let ((executed-effect (funcall effect)))
-          (when executed-effect
-            (symex--compute-results executed-traversal
-                                    nil
-                                    computation)))))))
+          (symex--compute-results executed-traversal
+                                  nil
+                                  computation))))))
 
 (defun symex--execute-traversal (traversal computation)
   "Helper to execute TRAVERSAL and perform COMPUTATION."

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -263,16 +263,20 @@ Evaluates to a COMPUTATION on the traversal actually executed."
                                 nil
                                 computation)))))
 
-(defun symex-execute-operation (operation computation)
-  "Attempt to execute a given OPERATION.
+(defun symex-execute-effect (effect computation)
+  "Attempt to execute a given EFFECT.
 
 Evaluates to a COMPUTATION on the traversal actually executed."
-  (let ((op (symex--operation-operation operation)))
-    (funcall op)
-    ;; TODO: compute based on an appropriate result here
-    (symex--compute-results symex--move-zero
-                            nil
-                            computation)))
+  (let ((traversal (symex--effect-traversal effect))
+        (effect (symex--effect-effect effect)))
+    (let ((executed-traversal (symex-execute-traversal traversal
+                                                       computation)))
+      (when executed-traversal
+        (let ((executed-effect (funcall effect)))
+          (when executed-effect
+            (symex--compute-results executed-traversal
+                                    nil
+                                    computation)))))))
 
 (defun symex--execute-traversal (traversal computation)
   "Helper to execute TRAVERSAL and perform COMPUTATION."
@@ -306,9 +310,9 @@ Evaluates to a COMPUTATION on the traversal actually executed."
         ((symex-paste-p traversal)
          (symex-execute-paste traversal
                               computation))
-        ((symex-operation-p traversal)
-         (symex-execute-operation traversal
-                                  computation))
+        ((symex-effect-p traversal)
+         (symex-execute-effect traversal
+                               computation))
         (t (funcall traversal))))
 
 (defun symex-execute-traversal (traversal &optional computation side-effect)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -128,9 +128,6 @@ to how the Lisp interpreter does it (when it is following
   (save-excursion
     (symex-execute-traversal (symex-traversal
                               (circuit symex--traversal-preorder-in-tree)))
-    ;; do it once first since it will be executed as a side-effect
-    ;; _after_ each step in the traversal
-    (symex--evaluate)
     (symex--do-while-traversing #'symex--evaluate
                                 symex--traversal-postorder-in-tree)))
 
@@ -138,9 +135,6 @@ to how the Lisp interpreter does it (when it is following
   "Evaluate the remaining symexes at this level."
   (interactive)
   (save-excursion
-    ;; do it once first since it will be executed as a side-effect
-    ;; _after_ each step in the traversal
-    (symex--evaluate)
     (symex--do-while-traversing #'symex--evaluate
                                 (symex-make-move 1 0))))
 

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -111,7 +111,7 @@ text, on the respective side."
   (let* ((text-to-paste
           ;; add the padding to the yanked text
           (concat before
-                  (current-kill 0 t)
+                  (symex--current-kill)
                   after))
          ;; remember initial point location
          (start (point)))
@@ -140,7 +140,7 @@ text, on the respective side."
          (surrounding-lines-empty (and previous-line-empty
                                        next-line-empty))
          (paste-text-contains-newlines
-          (seq-contains-p (current-kill 0 t) ?\n))
+          (seq-contains-p (symex--current-kill) ?\n))
          (at-eol (condition-case nil
                      (save-excursion (forward-sexp)
                                      (eolp))

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -711,11 +711,6 @@ effect is not performed during the pre-traversal."
          (yank)
          (goto-char 0)
          (symex-execute-traversal pre-traversal)
-         ;; do it once first since it will be executed as a side-effect
-         ;; _after_ each step in the traversal
-         (condition-case nil
-             (funcall side-effect)
-           (error nil))
          (condition-case nil
              (symex--do-while-traversing
               side-effect
@@ -782,9 +777,6 @@ implementation."
   (interactive)
   (save-excursion
     (symex--go-forward)
-    ;; do it once first since it will be executed as a side-effect
-    ;; _after_ each step in the traversal
-    (symex-insert-newline 1)
     (symex--do-while-traversing (apply-partially #'symex-insert-newline 1)
                                 (symex-make-move 1 0))))
 
@@ -792,9 +784,6 @@ implementation."
   "Tidy the remaining symexes."
   (interactive)
   (symex--save-point-excursion
-    ;; do it once first since it will be executed as a side-effect
-    ;; _after_ each step in the traversal
-    (symex--tidy 1)
     (symex--do-while-traversing (apply-partially #'symex--tidy 1)
                                 (symex-make-move 1 0))))
 

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -276,6 +276,9 @@ Executes the motion COUNT times."
 
 (defun symex--do-while-traversing (operation traversal)
   "Traverse a symex using TRAVERSAL and do OPERATION at each step."
+  ;; do it once first since it will be executed as a side-effect
+  ;; _after_ each step in the traversal
+  (funcall operation)
   (symex-execute-traversal
    (symex-traversal
     (circuit

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -276,13 +276,16 @@ Executes the motion COUNT times."
 
 (defun symex--do-while-traversing (operation traversal)
   "Traverse a symex using TRAVERSAL and do OPERATION at each step."
-  (let ((result (symex-execute-traversal traversal
-                                         nil
-                                         operation)))
-    (message "%s" result)
-    (when result
-      (symex--do-while-traversing operation
-                                  traversal))))
+  (symex-execute-traversal
+   (symex-traversal
+    (circuit
+     (effect traversal
+             ;; TODO: the semantics of effect is already to
+             ;; wrap the operation with a lambda and then
+             ;; invoke that during evaluation. It may make
+             ;; sense to avoid this double-wrapping.
+             (funcall operation))))
+   nil))
 
 
 (provide 'symex-traversals)

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -186,6 +186,10 @@ ring."
   (delete-region (line-beginning-position)
                  (1+ (line-end-position))))
 
+(defun symex--current-kill ()
+  "Get current kill ring entry without rotating the kill ring."
+  (current-kill 0 t))
+
 (defun symex--fix-leading-whitespace ()
   "Fix leading whitespace."
   ;; fix leading whitespace


### PR DESCRIPTION
### Summary of Changes

Formerly, side effects could be specified as a mode of evaluation (via a `side-effect` argument to `symex-execute-traversal`). Instead, this PR adds them as just a distinct traversal type, just like `maneuver` or `decision`. This allows us to attach side effects to any traversal or even components of traversals without needing to treat them in a special way. This simplifies the evaluator and gives us more flexibility in general.

I believe this also increases the power of the DSL from regular (finite automaton) to context-free (pushdown automaton), since we can leverage bindings in the ELisp lexical scope to store and update a variable (e.g. to use it as a stack). This is a little bit cheating since the memory representation isn't internal to the Symex language but is part of the host language (i.e. a Lisp variable defined and mutated in ELisp), but it's seamless enough for our purposes.

I'm not a computer scientist so if anyone else happens to have more thoughts on this I would be curious to understand further. But for example, we can now count things like this:

```
(defun my-count-remaining-expressions ()
  (let ((my-count 1))
    (symex-execute-traversal
     (symex-traversal
       (circuit (effect (move forward)
                        (setq my-count (1+ my-count))))))
    my-count))
```

Technically, as the return value of a traversal is (by default) the list of moves executed, we could also have counted the number of expressions by inspecting this return value, but once again, that would be an operation done in Lisp rather than Symex. Come to think of it, we can also define other kinds of fold-like computations in the existing evaluator that might be able to count, I don't recall now how that works or if it still works.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
