### PR TITLE
Fixes in primitives and deletion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ As of Jan 2023, there is "alpha" support for non-Lisp languages via ``tree-sitte
     <img src="https://user-images.githubusercontent.com/401668/59328521-6db96280-8ca1-11e9-8b32-24574a0af676.png" alt="Screenshot" title="Screenshot" style="cursor:default;"/>
   </p>
 
-.. [1] As long as, from a theoretical perspective, the intended traversal can be accomplished using a `finite automaton <https://en.wikipedia.org/wiki/Deterministic_finite_automaton>`_. More complex traversals can be implemented (such as "leap branch"), but not as easily. Symex may be made Turing-complete at some point in the future, if there is interest in a feature that cannot be implemented in the DSL in its current form.
+.. [1] As long as, from a theoretical perspective, the intended traversal can be accomplished using a `pushdown automaton <https://en.wikipedia.org/wiki/Pushdown_automaton>`_. That is, Symex is more expressive than regular expressions but less expressive than Lisp itself.
 
 Installation
 ============

--- a/symex-computations.el
+++ b/symex-computations.el
@@ -100,7 +100,7 @@ computation (each of the 'expressed' type) to yield the final result
   "The act procedure of the COMPUTATION."
   (nth 7 computation))
 
-(defun symex-compute-results (a b computation)
+(defun symex-compose-computation (a b computation)
   "Compose traversal results according to COMPUTATION.
 
 Combine the result of a traversal computation A with the accumulated

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -40,6 +40,11 @@
   :type 'boolean
   :group 'symex)
 
+(defcustom symex-toggle-blink-cursor t
+  "Whether to disable cursor blinking while in Symex state."
+  :type 'boolean
+  :group 'symex)
+
 (defcustom symex-remember-branch-positions-p t
   "Whether movement in the vertical direction should remember branch positions."
   :type 'boolean

--- a/symex-dsl.el
+++ b/symex-dsl.el
@@ -216,9 +216,9 @@ TRAVERSAL - the traversal to perform. This could be any traversal. If
 no traversal is specified, then the traversal is treated as the zero
 move, making this a pure side effect."
   `(symex-make-effect (lambda () ,effect)
-                      (if ,traversal
-                          (symex-traversal ,traversal)
-                        symex--move-zero)))
+                      ,(if traversal
+                           `(symex-traversal ,traversal)
+                         symex--move-zero)))
 
 ;; TODO: support args here like lambda / defun (i.e. as a list in the
 ;; binding form -- not passed in but syntactically inserted)

--- a/symex-evaluator.el
+++ b/symex-evaluator.el
@@ -68,10 +68,10 @@ Optional argument COMPUTATION currently unused."
                     (funcall (symex--computation-perceive computation)
                              symex--move-zero))))
     (when executed-move
-      (symex-compute-results result
-                             (funcall (symex--computation-perceive computation)
-                                      executed-move)
-                             computation))))
+      (symex-compose-computation result
+                                 (funcall (symex--computation-perceive computation)
+                                          executed-move)
+                                 computation))))
 
 (defun symex-execute-maneuver (maneuver computation result)
   "Attempt to execute a given MANEUVER.

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -607,6 +607,8 @@ ORIG-FN applied to ARGS is the invocation being advised."
   (unless (member evil-next-state '(emacslike normallike))
     ;; these are "internal" state transitions, used in e.g. symex-evaluate
     (deactivate-mark)
+    (when symex--original-blink-cursor-state
+      (blink-cursor-mode 1))
     (when symex-refocus-p
       (symex--restore-scroll-margin))
     (symex--primitive-exit)))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -165,7 +165,7 @@
 (defvar symex--re-blank-line "^[[:space:]]*$"
   "A blank line, either empty or containing only whitespace.")
 
-(defvar symex--re-whitespace "[[:space:]|\n]*"
+(defvar symex--re-whitespace "[[:space:]|\n]+"
   "Whitespace that may extend over many lines.")
 
 (defvar symex--re-symex-line "^[[:space:]]*[^;[:space:]\n]"
@@ -210,6 +210,10 @@
   "Move point to the other delimiter in a matching pair."
   (cond ((looking-at "\\s(") (forward-list 1) (backward-char 1))
         ((looking-at "\\s)") (forward-char 1) (backward-list 1))))
+
+(defun symex-whitespace-p ()
+  "Check if we're looking at whitespace."
+  (looking-at-p symex--re-whitespace))
 
 (defun symex-comment-line-p ()
   "Check if we're currently at the start of a comment line."
@@ -424,8 +428,9 @@ including trailing whitespace at the end of the last symex."
     (let ((endpoint (symex-lisp--get-end-point-helper count)))
       (if include-whitespace
           (progn (goto-char endpoint)
-                 (if (symex--go-to-next-non-whitespace-char)
-                     (1- (point))
+                 (if (and (not (eobp))
+                          (symex-whitespace-p))
+                     (1+ endpoint)
                    endpoint))
         endpoint))))
 
@@ -678,7 +683,7 @@ line."
                              (error nil))
                      (symex--join-to-match symex--re-right))))))))
         ((symex-right-p) (fixup-whitespace)) ; abc <>)
-        (t (symex--join-to-non-whitespace))))
+        (t nil)))
 
 ;;; Utilities
 

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -168,6 +168,9 @@
 (defvar symex--re-whitespace "[[:space:]|\n]+"
   "Whitespace that may extend over many lines.")
 
+(defvar symex--re-optional-whitespace "[[:space:]|\n]*"
+  "Optional whitespace that may extend over many lines.")
+
 (defvar symex--re-symex-line "^[[:space:]]*[^;[:space:]\n]"
   "A line that isn't blank and isn't a comment line.")
 
@@ -245,7 +248,7 @@
   "Check if we're looking at an empty list."
   (looking-at-p
    (concat symex--re-left
-           symex--re-whitespace
+           symex--re-optional-whitespace
            symex--re-right)))
 
 (defun symex-empty-string-p ()
@@ -258,10 +261,10 @@
 (defun symex-inside-empty-form-p ()
   "Check if point is inside an empty form."
   (and (looking-back (concat symex--re-left
-                             symex--re-whitespace)
+                             symex--re-optional-whitespace)
                      (line-beginning-position))
        (looking-at-p
-        (concat symex--re-whitespace
+        (concat symex--re-optional-whitespace
                 symex--re-right))))
 
 (defun symex--racket-syntax-object-p ()

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -636,7 +636,7 @@ line."
                  (symex--previous-line-empty-p))
              (symex--join-to-next)
            ;; don't leave an empty line where the symex was
-           (symex--kill-whole-line)))
+           (symex--delete-whole-line)))
         ((or (save-excursion (evil-last-non-blank) ; (<>$
                              (symex-left-p)))
          (symex--join-to-next))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -395,7 +395,7 @@ as special cases here."
         (error nil)))
     (point)))
 
-(defun symex-lisp--get-end-point-helper (count)
+(defun symex-lisp--get-end-point-helper (count include-whitespace)
   "Helper to get the point value after COUNT symexes.
 
 If the containing expression terminates earlier than COUNT
@@ -403,19 +403,31 @@ symexes, returns the end point of the last one found.
 
 Note that this mutates point - it should not be called directly."
   (if (= count 0)
-      (point)
+      (progn
+        (when include-whitespace
+          (symex--go-to-next-non-whitespace-char))
+        (point))
     (condition-case nil
         (forward-sexp)
-      (error (point)))
-    (symex-lisp--get-end-point-helper (1- count))))
+      (error
+       (progn
+         (when include-whitespace
+           (symex--go-to-next-non-whitespace-char))
+         (point))))
+    (symex-lisp--get-end-point-helper (1- count)
+                                      include-whitespace)))
 
-(defun symex-lisp--get-end-point (count)
+(defun symex-lisp--get-end-point (count &optional include-whitespace)
   "Get the point value after COUNT symexes.
 
 If the containing expression terminates earlier than COUNT
-symexes, returns the end point of the last one found."
+symexes, returns the end point of the last one found.
+
+If include-whitespace is non-nil, this returns the end point
+including trailing whitespace at the end of the last symex."
   (save-excursion
-    (symex-lisp--get-end-point-helper count)))
+    (symex-lisp--get-end-point-helper count
+                                      include-whitespace)))
 
 (defun symex-lisp--point-height-offset ()
   "Compute the height offset of the current symex.

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -254,14 +254,8 @@ WHAT could be `this`, `next`, or `previous`."
            (setq result (symex-remove 1)))
           ((eq 'previous what)
            (when (symex--previous-p)
-             ;; note the bounds of the mutated region
-             ;; and manually preserve point where we need it
-             (let ((start (symex-save-excursion
-                            (symex--go-backward)
-                            (symex--get-starting-point))))
-               (symex--go-backward)
-               (setq result (symex-remove 1))
-               (goto-char start))))
+             (symex--go-backward)
+             (setq result (symex-remove 1))))
           ((eq 'next what)
            (when (symex--next-p)
              (save-excursion

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -250,18 +250,24 @@ from the buffer."
 
 WHAT could be `this`, `next`, or `previous`."
   (let ((result))
-    (cond ((eq 'this what)
-           (setq result (symex-remove 1)))
-          ((eq 'previous what)
-           (when (symex--previous-p)
-             (symex--go-backward)
-             (setq result (symex-remove 1))))
-          ((eq 'next what)
-           (when (symex--next-p)
-             (save-excursion
-               (symex--go-forward)
-               (setq result (symex-remove 1)))))
-          (t (error "Invalid argument for primitive delete!")))
+    (condition-case nil
+        (cond ((eq 'this what)
+               (setq result (symex-remove 1)))
+              ((eq 'previous what)
+               (when (symex--previous-p)
+                 (symex--go-backward)
+                 (setq result (symex-remove 1))))
+              ((eq 'next what)
+               (when (symex--next-p)
+                 (save-excursion
+                   (symex--go-forward)
+                   (setq result (symex-remove 1)))))
+              (t (error "Invalid argument for primitive delete!")))
+      ;; if unable to delete, return nil instead of
+      ;; raising an error. nil is used in the evaluator
+      ;; to mean failed, so the traversal would stop there
+      ;; as expected.
+      (error nil))
     result))
 
 (defun symex-prim-paste (where)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -221,7 +221,6 @@ from the buffer."
         (end (symex--get-end-point count t)))
     (when (> end start)
       (kill-region start end)
-      (fixup-whitespace) ; TODO: verify this is needed
       t)))
 
 (defun symex--reset-after-delete ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -218,9 +218,10 @@ This is a low-level utility that simply removes the indicated text
 from the buffer."
   (let ((last-command nil)  ; see symex-yank re: last-command
         (start (point))
-        (end (symex--get-end-point count)))
+        (end (symex--get-end-point count t)))
     (when (> end start)
       (kill-region start end)
+      (fixup-whitespace) ; TODO: verify this is needed
       t)))
 
 (defun symex--reset-after-delete ()
@@ -327,14 +328,21 @@ difference from the lowest such level."
       (symex-ts--get-starting-point)
     (symex-lisp--get-starting-point)))
 
-(defun symex--get-end-point (count)
+(defun symex--get-end-point (count &optional include-whitespace)
   "Get the point value after COUNT symexes.
 
 If the containing expression terminates earlier than COUNT
 symexes, returns the end point of the last one found."
   (if (symex-tree-sitter-p)
+      ;; TODO: implement include-whitespace for ts
       (symex-ts--get-end-point count)
-    (symex-lisp--get-end-point count)))
+    (symex-lisp--get-end-point count include-whitespace)))
+
+(defun symex--get-bounds (count &optional include-whitespace)
+  "Get the start and end points of COUNT symexes."
+  (let ((start (symex--get-starting-point))
+        (end (symex--get-end-point count include-whitespace)))
+    (cons start end)))
 
 (defun symex-select-end (count)
   "Select endpoint of symex nearest to point."

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -255,16 +255,14 @@ WHAT could be `this`, `next`, or `previous`."
            (setq result (symex-remove 1)))
           ((eq 'previous what)
            (when (symex--previous-p)
-             ;; not sure how reliable `save-excursion` is when
-             ;; the buffer is being mutated. If we encounter
-             ;; any issues we could try `symex--save-point-excursion`
-             ;; or otherwise, note the bounds of the mutated region
-             ;; and manually preserve point where we need it, or
-             ;; if necessary, preserve point structurally by using
-             ;; a primitive version of `symex-index`.
-             (symex-save-excursion
+             ;; note the bounds of the mutated region
+             ;; and manually preserve point where we need it
+             (let ((start (symex-save-excursion
+                            (symex--go-backward)
+                            (symex--get-starting-point))))
                (symex--go-backward)
-               (setq result (symex-remove 1)))))
+               (setq result (symex-remove 1))
+               (goto-char start))))
           ((eq 'next what)
            (when (symex--next-p)
              (save-excursion

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -121,61 +121,62 @@ text, on the respective side."
 
 (defun symex-lisp--padding (&optional before)
   "Determine paste padding needed for current point position."
-  (let* ((after (not before))
-         (island
-          (and (bolp)
-               (condition-case nil
-                   (save-excursion (forward-sexp)
-                                   (eolp))
-                 (error nil))))
-         (at-eob
-          (condition-case nil
-              (save-excursion (forward-sexp)
-                              (eobp))
-            (error nil)))
-         (previous-line-empty
-          (symex--previous-line-empty-p))
-         (next-line-empty
-          (symex--following-line-empty-p))
-         (surrounding-lines-empty (and previous-line-empty
-                                       next-line-empty))
-         (paste-text-contains-newlines
-          (seq-contains-p (symex--current-kill) ?\n))
-         (at-eol (condition-case nil
+  (if (symex-inside-empty-form-p)
+      ""
+    (let* ((after (not before))
+           (island
+            (and (bolp)
+                 (condition-case nil
                      (save-excursion (forward-sexp)
                                      (eolp))
-                   (error nil)))
-         (multiline (let ((original-line (line-number-at-pos)))
-                      (condition-case nil
-                          (save-excursion (forward-sexp)
-                                          (not (= original-line
-                                                  (line-number-at-pos))))
-                        (error nil)))))
-    (cond ((and island
-                ;; if we're at the toplevel, on an "island" symex
-                ;; (i.e. with no peers occupying the same lines),
-                (or (and after next-line-empty)
-                    ;; and if the side we want to paste on already
-                    ;; contains an empty line,
-                    (and before previous-line-empty)
-                    ;; or if we happen to be at the end of the buffer
-                    ;; for pasting after, then check the opposite side
-                    ;; instead for the clue on what's expected
-                    (and at-eob previous-line-empty))
-                ;; and if the text to be pasted contains newlines, or
-                ;; if both surrounding lines are empty _and_ we aren't
-                ;; at the first symex
-                (or paste-text-contains-newlines
-                    (and surrounding-lines-empty
-                         (not (symex--point-at-first-symex-p)))))
-                ;; then we typically want an extra newline separator
-           "\n\n")
-          ((or (symex--point-at-indentation-p)
-               at-eol
-               multiline)
-           "\n")
-          ((symex-inside-empty-form-p) "")
-          (t " "))))
+                   (error nil))))
+           (at-eob
+            (condition-case nil
+                (save-excursion (forward-sexp)
+                                (eobp))
+              (error nil)))
+           (previous-line-empty
+            (symex--previous-line-empty-p))
+           (next-line-empty
+            (symex--following-line-empty-p))
+           (surrounding-lines-empty (and previous-line-empty
+                                         next-line-empty))
+           (paste-text-contains-newlines
+            (seq-contains-p (symex--current-kill) ?\n))
+           (at-eol (condition-case nil
+                       (save-excursion (forward-sexp)
+                                       (eolp))
+                     (error nil)))
+           (multiline (let ((original-line (line-number-at-pos)))
+                        (condition-case nil
+                            (save-excursion (forward-sexp)
+                                            (not (= original-line
+                                                    (line-number-at-pos))))
+                          (error nil)))))
+      (cond ((and island
+                  ;; if we're at the toplevel, on an "island" symex
+                  ;; (i.e. with no peers occupying the same lines),
+                  (or (and after next-line-empty)
+                      ;; and if the side we want to paste on already
+                      ;; contains an empty line,
+                      (and before previous-line-empty)
+                      ;; or if we happen to be at the end of the buffer
+                      ;; for pasting after, then check the opposite side
+                      ;; instead for the clue on what's expected
+                      (and at-eob previous-line-empty))
+                  ;; and if the text to be pasted contains newlines, or
+                  ;; if both surrounding lines are empty _and_ we aren't
+                  ;; at the first symex
+                  (or paste-text-contains-newlines
+                      (and surrounding-lines-empty
+                           (not (symex--point-at-first-symex-p)))))
+             ;; then we typically want an extra newline separator
+             "\n\n")
+            ((or (symex--point-at-indentation-p)
+                 at-eol
+                 multiline)
+             "\n")
+            (t " ")))))
 
 (defun symex-lisp--paste-before ()
   "Paste before symex."

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -179,12 +179,18 @@ text, on the respective side."
             ((and before
                   (string-match-p (concat symex--re-whitespace "$")
                                   (symex--current-kill)))
+             ;; if the text to be pasted before includes whitespace already,
+             ;; then don't add more
              "")
             (t " ")))))
 
 (defun symex-lisp--paste-before ()
   "Paste before symex."
   (interactive)
+  (when (symex-inside-empty-form-p)
+    (symex--kill-ring-push
+     (string-trim-right
+      (symex--kill-ring-pop))))
   (symex-lisp--paste ""
                      (symex-lisp--padding t)))
 
@@ -217,10 +223,10 @@ If a symex is currently selected, then paste after the end of the
 selected expression. Otherwise, paste in place."
   (interactive)
   (let ((padding (symex-lisp--padding nil)))
-    (if (symex-lisp--point-at-last-symex-p)
-        (symex--kill-ring-push
-         (string-trim-right
-          (symex--kill-ring-pop))))
+    (when (symex-lisp--point-at-last-symex-p)
+      (symex--kill-ring-push
+       (string-trim-right
+        (symex--kill-ring-pop))))
     (save-excursion
       (condition-case nil
           (forward-sexp)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -176,6 +176,10 @@ text, on the respective side."
                  at-eol
                  multiline)
              "\n")
+            ((and before
+                  (string-match-p (concat symex--re-whitespace "$")
+                                  (symex--current-kill)))
+             "")
             (t " ")))))
 
 (defun symex-lisp--paste-before ()
@@ -213,6 +217,10 @@ If a symex is currently selected, then paste after the end of the
 selected expression. Otherwise, paste in place."
   (interactive)
   (let ((padding (symex-lisp--padding nil)))
+    (if (symex-lisp--point-at-last-symex-p)
+        (symex--kill-ring-push
+         (string-trim-right
+          (symex--kill-ring-pop))))
     (save-excursion
       (condition-case nil
           (forward-sexp)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -188,13 +188,14 @@ text, on the respective side."
   (symex--with-undo-collapse
     (let ((pasted-text (symex-lisp--paste-before)))
       (save-excursion
-        (let* ((end (+ (point) (length pasted-text)))
+        (let* ((end (point))
+               (start (- end (length pasted-text)))
                (end-line (line-number-at-pos end)))
           ;; we use end + 1 here since end is the point
           ;; right before the initial expression, which
           ;; won't be indented as it thus would fall
           ;; outside the region to be indented.
-          (indent-region (point) (1+ end))
+          (indent-region start (1+ end))
           ;; indenting may add characters (e.g. spaces)
           ;; to the buffer, so we rely on the line number
           ;; instead.
@@ -221,14 +222,18 @@ selected expression. Otherwise, paste in place."
 (defun symex-lisp-paste-after ()
   "Paste after symex."
   (symex--with-undo-collapse
-    (let ((pasted-text (symex-lisp--paste-after))
-          (selected (symex-lisp--selected-p)))
+    (let ((selected (symex-lisp--selected-p))
+          (pasted-text (symex-lisp--paste-after)))
       (save-excursion
         (when selected
+          ;; if it was (|), then we are already at the start
+          ;; of the pasted text
           (forward-sexp)) ; go to beginning of pasted text
-        (goto-char (+ (point)
-                      (length pasted-text))) ; end of pasted text
-        (symex--same-line-tidy-affected))
+        (let* ((start (point))
+               (end (+ start
+                       (length pasted-text))))
+          (goto-char end)
+          (symex--same-line-tidy-affected)))
       (not (equal pasted-text "")))))
 
 (defun symex-lisp-yank (count)

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -105,7 +105,7 @@ If the deletion results in an empty line it will be removed."
   (when (symex--current-line-empty-p)
     (if (symex--previous-line-empty-p)
         (symex--join-to-non-whitespace)
-      (symex--kill-whole-line))))
+      (symex--delete-whole-line))))
 
 (defun symex-ts-delete-node-forward (&optional count)
   "Delete COUNT nodes forward from the current node."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -103,20 +103,12 @@
   ;; to be fewer than count expressions following, then we may delete
   ;; preceding expressions too. But we typically mean to delete only
   ;; the succeeding expressions here.
-  ;;
-  ;; In lieu of doing it in two traversals, we could potentially
-  ;; either introduce a new traversal type that always executes every
-  ;; subexpression even if any of them fail, or, we could first
-  ;; compute (either in symex or in Elisp) the number of succeeding
-  ;; expressions or count, whichever is lower, and then execute the
-  ;; deletion traversal on that modified count.
-  (symex-execute-traversal
-   (symex-traversal
-    (circuit (delete next)
-             (1- count))))
-  (symex-execute-traversal
-   (symex-traversal
-    (delete this))))
+  (let ((count (min (symex-remaining-length)
+                    count)))
+    (symex-execute-traversal
+     (symex-traversal
+       (circuit (delete this)
+                count)))))
 
 (symex-define-command symex-delete (count)
   "Delete COUNT symexes."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -315,6 +315,12 @@ by default, joins next symex to current one."
   "Paste after symex, COUNT times."
   (interactive "p")
   (setq this-command 'evil-paste-after)
+  ;; TODO: user-level defcustom of whether to move
+  ;; to indicate pasted text (like evil), which should
+  ;; be checked here and appropriately applied. E.g.
+  ;; in Lisp, (|) currently would move when it shouldn't
+  ;; but it's a default that works in the majority of
+  ;; cases to provide evil-like behavior.
   (symex-execute-traversal
    (symex-traversal
     (maneuver (circuit (paste after)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -102,13 +102,24 @@
   ;; if we attempt to just (delete this) count times, if there happen
   ;; to be fewer than count expressions following, then we may delete
   ;; preceding expressions too. But we typically mean to delete only
-  ;; the succeeding expressions here.
+  ;; the succeeding expressions here. That's why we count the number
+  ;; of remaining expressions first.
   (let ((count (min (symex-remaining-length)
                     count)))
-    (symex-execute-traversal
-     (symex-traversal
-       (circuit (delete this)
-                count)))))
+    (when (> count 0)
+      ;; when deleting multiple expressions, we typically want to
+      ;; treat them as a single deletion, so we compose the entries on
+      ;; the kill ring as a side effect of each deletion
+      (symex--kill-ring-push "")
+      (symex-execute-traversal
+       (symex-traversal
+         (circuit (effect (symex--kill-ring-compose)
+                          (delete this))
+                  count)))
+      ;; trim trailing whitespace at the end
+      ;; otherwise, paste will include that
+      (let ((result (symex--kill-ring-pop)))
+        (symex--kill-ring-push (string-trim-right result))))))
 
 (symex-define-command symex-delete (count)
   "Delete COUNT symexes."

--- a/symex-ui.el
+++ b/symex-ui.el
@@ -44,9 +44,12 @@
   "Update the highlight overlay to match the start/end position of NODE."
   (when symex--current-overlay
     (delete-overlay symex--current-overlay))
-  (setq-local symex--current-overlay
-              (make-overlay (symex--get-starting-point)
-                            (symex--get-end-point 1)))
+  (let* ((start (symex--get-starting-point))
+         (end (condition-case nil
+                  (symex--get-end-point 1)
+                (error start))))
+    (setq-local symex--current-overlay
+                (make-overlay start end)))
   (overlay-put symex--current-overlay 'face 'symex--current-node-face))
 
 (defun symex--overlay-active-p ()

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -184,6 +184,25 @@ ring."
   "Get current kill ring entry without rotating the kill ring."
   (current-kill 0 t))
 
+(defun symex--kill-ring-push (entry)
+  "Push an ENTRY onto the kill ring."
+  (push entry kill-ring)
+  (setq kill-ring-yank-pointer kill-ring))
+
+(defun symex--kill-ring-pop ()
+  "Pop the latest entry off the kill ring."
+  (let ((result (pop kill-ring)))
+    (setq kill-ring-yank-pointer kill-ring)
+    result))
+
+(defun symex--kill-ring-compose ()
+  "Compose kill ring entries.
+
+This concatenates the latest kill with the preceding one, treating the
+preceding one as the accumulator. "
+  (let ((latest (symex--kill-ring-pop)))
+    (kill-append latest t)))
+
 (defun symex--fix-leading-whitespace ()
   "Fix leading whitespace."
   ;; fix leading whitespace

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -79,7 +79,8 @@ If the current character is non-whitespace, point is not moved."
     (condition-case nil
         (progn (re-search-forward symex--re-non-whitespace)
                ;; since the re search goes to the end of the match
-               (backward-char))
+               (backward-char)
+               t)
       (error nil))))
 
 (defun symex--join-to-match (pattern)

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -71,6 +71,9 @@ the following recipe instead."
 (defvar symex--re-non-whitespace "[^[:space:]\n]"
   "A non-whitespace character.")
 
+(defvar symex--re-non-whitespace-or-newline "[^[:space:]]"
+  "A non-whitespace character.")
+
 (defun symex--go-to-next-non-whitespace-char ()
   "Move point to the next non-whitespace character.
 
@@ -100,6 +103,13 @@ match."
 This eliminates whitespace between the original position and the found
 match."
   (symex--join-to-match symex--re-non-whitespace))
+
+(defun symex--join-to-non-whitespace-or-newline ()
+  "Join current position to the next non-whitespace character.
+
+This eliminates whitespace between the original position and the found
+match."
+  (symex--join-to-match symex--re-non-whitespace-or-newline))
 
 ;; `with-undo-collapse` macro, to treat a sequence of operations
 ;; as a single entry in the undo list.

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -186,8 +186,7 @@ ring."
 
 (defun symex--kill-ring-push (entry)
   "Push an ENTRY onto the kill ring."
-  (push entry kill-ring)
-  (setq kill-ring-yank-pointer kill-ring))
+  (kill-new entry))
 
 (defun symex--kill-ring-pop ()
   "Pop the latest entry off the kill ring."
@@ -201,7 +200,7 @@ ring."
 This concatenates the latest kill with the preceding one, treating the
 preceding one as the accumulator. "
   (let ((latest (symex--kill-ring-pop)))
-    (kill-append latest t)))
+    (kill-append latest nil)))
 
 (defun symex--fix-leading-whitespace ()
   "Fix leading whitespace."

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -176,7 +176,9 @@ result."
 Similar to `kill-whole-line` but doesn't add an entry to the kill
 ring."
   (delete-region (line-beginning-position)
-                 (1+ (line-end-position))))
+                 (line-end-position))
+  (unless (eobp)
+    (delete-char 1)))
 
 (defun symex--current-kill ()
   "Get current kill ring entry without rotating the kill ring."

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -76,9 +76,11 @@ the following recipe instead."
 
 If the current character is non-whitespace, point is not moved."
   (unless (looking-at-p symex--re-non-whitespace)
-    (re-search-forward symex--re-non-whitespace)
-    ;; since the re search goes to the end of the match
-    (backward-char)))
+    (condition-case nil
+        (progn (re-search-forward symex--re-non-whitespace)
+               ;; since the re search goes to the end of the match
+               (backward-char))
+      (error nil))))
 
 (defun symex--join-to-match (pattern)
   "Join current position to the next position matching PATTERN.

--- a/symex-utils.el
+++ b/symex-utils.el
@@ -170,7 +170,7 @@ result."
       (cl-pushnew p result :key #'car :test #'equal))
     result))
 
-(defun symex--kill-whole-line ()
+(defun symex--delete-whole-line ()
   "Delete entire current line.
 
 Similar to `kill-whole-line` but doesn't add an entry to the kill

--- a/symex.el
+++ b/symex.el
@@ -47,6 +47,8 @@
 (require 'tree-sitter)
 (require 'symex-ts)
 
+(defvar symex--original-blink-cursor-state nil)
+
 ;;;###autoload
 (define-minor-mode symex-mode
   "An evil way to edit Lisp symbolic expressions as trees."
@@ -110,6 +112,9 @@
   (symex--adjust-point-on-entry)
   (when symex-remember-branch-positions-p
     (symex--clear-branch-memory))
+  (when symex-toggle-blink-cursor
+    (setq symex--original-blink-cursor-state blink-cursor-mode)
+    (blink-cursor-mode -1))
   (symex-user-select-nearest)
   (when symex-refocus-p
     ;; smooth scrolling currently not supported


### PR DESCRIPTION
### Summary of Changes

Some fixes and improvements, including:

- restore emit and capture to working / sensible behavior
- fix deleting and pasting with counts, e.g. `3x` followed by `p` should paste all three expressions (formerly was only pasting the most recently deleted one)
- better handling of surrounding whitespace in deletion
- disable blink cursor in symex state
- other minor improvements and fixes

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
