### PR TITLE
[Issue 137] Trigger eldoc after symex motions

### DIFF
--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -49,8 +49,6 @@
                (beforehand (not (at root)))))
   "Go to lowest (root) symex in present tree.")
 
-(defvar symex-motions ())
-
 (defmacro symex-define-motion (name
                                args
                                docstring
@@ -59,7 +57,7 @@
                                body)
   "Define a symex motion."
   (declare (indent defun))
-  (add-to-list 'symex-motions name)
+  (eldoc-add-command name)
   `(defun ,name ,args
      ,docstring
      ,interactive-decl

--- a/symex-traversals.el
+++ b/symex-traversals.el
@@ -49,25 +49,42 @@
                (beforehand (not (at root)))))
   "Go to lowest (root) symex in present tree.")
 
-(defun symex-goto-first ()
+(defvar symex-motions ())
+
+(defmacro symex-define-motion (name
+                               args
+                               docstring
+                               interactive-decl
+                               &rest
+                               body)
+  "Define a symex motion."
+  (declare (indent defun))
+  (add-to-list 'symex-motions name)
+  `(defun ,name ,args
+     ,docstring
+     ,interactive-decl
+     ,@body))
+
+(symex-define-motion symex-goto-first ()
   "Select first symex at present level."
   (interactive)
   (symex-execute-traversal symex--traversal-goto-first)
   (point))
 
-(defun symex-goto-last ()
+
+(symex-define-motion symex-goto-last ()
   "Select last symex at present level."
   (interactive)
   (symex-execute-traversal symex--traversal-goto-last)
   (point))
 
-(defun symex-goto-lowest ()
+(symex-define-motion symex-goto-lowest ()
   "Select lowest symex."
   (interactive)
   (symex-execute-traversal symex--traversal-goto-lowest)
   (point))
 
-(defun symex-goto-highest ()
+(symex-define-motion symex-goto-highest ()
   "Select highest symex."
   (interactive)
   (symex-execute-traversal (symex-traversal
@@ -132,7 +149,7 @@ when the way is blocked.")
                      (precaution symex--traversal-goto-first
                                  (beforehand (not (at root)))))))
 
-(defun symex-traverse-forward (count)
+(symex-define-motion symex-traverse-forward (count)
   "Traverse symex as a tree, using pre-order traversal.
 
 Executes the motion COUNT times."
@@ -140,7 +157,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-preorder)))
 
-(defun symex-traverse-forward-more (count)
+(symex-define-motion symex-traverse-forward-more (count)
   "Traverse symex as a tree, using pre-order traversal.
 
 Moves more steps at a time.  Executes the motion COUNT times."
@@ -148,7 +165,7 @@ Moves more steps at a time.  Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-traverse-forward 3)))
 
-(defun symex-traverse-forward-in-tree (count)
+(symex-define-motion symex-traverse-forward-in-tree (count)
   "Traverse symex forward using pre-order traversal, stopping at end of tree.
 
 Executes the motion COUNT times."
@@ -156,7 +173,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-preorder-in-tree)))
 
-(defun symex-traverse-forward-skip (count)
+(symex-define-motion symex-traverse-forward-skip (count)
   "Traverse symex as a tree, skipping forward.
 
 Executes the motion COUNT times."
@@ -164,7 +181,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-skip-forward)))
 
-(defun symex-traverse-backward (count)
+(symex-define-motion symex-traverse-backward (count)
   "Traverse symex as a tree, using converse post-order traversal.
 
 Executes the motion COUNT times."
@@ -172,7 +189,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-postorder)))
 
-(defun symex-traverse-backward-more (count)
+(symex-define-motion symex-traverse-backward-more (count)
   "Traverse symex as a tree, using pre-order traversal.
 
 Moves more steps at a time.  Executes the motion COUNT times."
@@ -180,7 +197,7 @@ Moves more steps at a time.  Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-traverse-backward 3)))
 
-(defun symex-traverse-backward-in-tree (count)
+(symex-define-motion symex-traverse-backward-in-tree (count)
   "Traverse symex backward using post-order traversal, stopping at root of tree.
 
 Executes the motion COUNT times."
@@ -188,7 +205,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-postorder-in-tree)))
 
-(defun symex-traverse-backward-skip (count)
+(symex-define-motion symex-traverse-backward-skip (count)
   "Traverse symex as a tree, skipping backwards.
 
 Executes the motion COUNT times."
@@ -196,7 +213,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-skip-backward)))
 
-(defun symex-climb-branch (count)
+(symex-define-motion symex-climb-branch (count)
   "Climb up.
 
 Executes the motion COUNT times."
@@ -204,7 +221,7 @@ Executes the motion COUNT times."
   (dotimes (_ count)
     (symex-execute-traversal symex--traversal-climb-branch)))
 
-(defun symex-descend-branch (count)
+(symex-define-motion symex-descend-branch (count)
   "Descend the tree.
 
 Executes the motion COUNT times."

--- a/symex.el
+++ b/symex.el
@@ -138,6 +138,7 @@ This registers symex mode for use in all recognized Lisp modes, and also
 advises functions to enable or disable features based on user configuration."
 
   (symex-register-builtin-interfaces)
+
   ;; enable the symex minor mode in all recognized lisp modes
   (dolist (mode-name (symex-get-lisp-modes))
     (let ((mode-hook (intern (concat (symbol-name mode-name)
@@ -158,7 +159,9 @@ advises functions to enable or disable features based on user configuration."
   (cond ((eq symex-modal-backend 'hydra)
          (symex-hydra-initialize))
         ((eq symex-modal-backend 'evil)
-         (symex-evil-initialize))))
+         (symex-evil-initialize)))
+  ;; notify eldoc about symex motions.
+  (apply 'eldoc-add-command symex-motions))
 
 (defun symex-disable ()
   "Disable symex.

--- a/symex.el
+++ b/symex.el
@@ -138,7 +138,6 @@ This registers symex mode for use in all recognized Lisp modes, and also
 advises functions to enable or disable features based on user configuration."
 
   (symex-register-builtin-interfaces)
-
   ;; enable the symex minor mode in all recognized lisp modes
   (dolist (mode-name (symex-get-lisp-modes))
     (let ((mode-hook (intern (concat (symbol-name mode-name)
@@ -159,9 +158,7 @@ advises functions to enable or disable features based on user configuration."
   (cond ((eq symex-modal-backend 'hydra)
          (symex-hydra-initialize))
         ((eq symex-modal-backend 'evil)
-         (symex-evil-initialize)))
-  ;; notify eldoc about symex motions.
-  (apply 'eldoc-add-command symex-motions))
+         (symex-evil-initialize))))
 
 (defun symex-disable ()
   "Disable symex.


### PR DESCRIPTION
### Summary of Changes

As dicussed in [issue 137](https://github.com/drym-org/symex.el/issues/137) eldoc is no longer working well.

As discussed, the `def-symex-motion` macro has been introduce in order to keep track of the list of available motions.

Those motions can be fed to `eldoc-add-comand` (during `symex-initialize`) in order to restore eldoc behavior.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
