### PR TITLE
Remove `forward-sexp` call in `symex-eval-print-elisp`

### DIFF
--- a/symex-interface-elisp.el
+++ b/symex-interface-elisp.el
@@ -39,9 +39,7 @@
 
 (defun symex-eval-print-elisp ()
   "Eval symex and print result in buffer."
-  (save-excursion
-    (forward-sexp)
-    (eval-print-last-sexp)))
+  (eval-print-last-sexp))
 
 (defun symex-describe-symbol-elisp ()
   "Describe symbol at point."


### PR DESCRIPTION
### Summary of Changes

In the elisp implementation of `symex-eval-print`, the `forward-sexp` call is not needed (it is done in the `symex-eval-print` before the actual implementation being called)

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
