### PR TITLE
Fix broken overlay when focussing on first symex of a string

### DIFF
--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -110,6 +110,8 @@
                 (or (bolp)                          ; ^|.
                     (looking-back "[[:space:]]"     ; _|.
                                   (line-beginning-position))
+                    (save-excursion (backward-char)
+                                    (symex-string-p))
                     (looking-back lispy-left        ; (*|.
                                   (line-beginning-position)))))))
 


### PR DESCRIPTION
### Summary of Changes

When the point is on the first symex of a string, the `symex-lisp--point-at-start-p` returns nil instead of true.
It brokes the overlay badly.
By adding a clause to `symex-lisp--point-at-start-p` the issue seems to be fixed but maybe I miss something.

https://github.com/drym-org/symex.el/assets/4739483/9bf7f2dc-dbc8-40a7-9a7b-0cd169c9169d

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
