### PR TITLE
Handling entering symex interface from inside a string

### DIFF
--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -263,6 +263,8 @@ as special cases here."
               (save-excursion (forward-char) (lispy-right-p))) ; |)
          (forward-char)
          (lispy-different))
+        ((thing-at-point 'string)       ; "som|e string"
+         (beginning-of-thing 'string))
         ((thing-at-point 'sexp)       ; som|ething
          (beginning-of-thing 'sexp))
         (t (symex-lisp--if-stuck (symex-lisp--backward)


### PR DESCRIPTION
### Summary of Changes

As discussed in [#140](https://github.com/drym-org/symex.el/pull/140), strings are treated as atomic entities in symex.
That being said I think it make sense to select the whole string when entering symex interface from within.

https://github.com/drym-org/symex.el/assets/4739483/8c704afa-76f0-4601-ad7f-f3a2e58db746

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
