### PR TITLE
Builtin treesitter

### DIFF
--- a/dev/dev-utils.el
+++ b/dev/dev-utils.el
@@ -20,7 +20,9 @@
   "Update the highlight overlay to match the start/end position of NODE."
   (when symex-ts--current-overlay
     (delete-overlay symex-ts--current-overlay))
-  (setq-local symex-ts--current-overlay (make-overlay (tsc-node-start-position node) (tsc-node-end-position node)))
+  (setq-local symex-ts--current-overlay
+              (make-overlay (symex-ts--node-start-position node)
+                            (symex-ts--node-end-position node)))
   (overlay-put symex-ts--current-overlay 'face 'symex-ts-current-node-face))
 
 (defun symex-ts--hydra-exit ()

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -37,7 +37,7 @@
 
 (defun symex-tree-sitter-p ()
   "Whether to use the tree sitter primitives."
-  (and tree-sitter-mode
+  (and (and (treesit-available-p) (> (length (treesit-parser-list)) 0))
        ;; We use the Lisp primitives for Clojure
        ;; even though Emacs 29 provides tree-sitter APIs
        ;; for it, since the Lisp primitives in Symex are

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -49,7 +49,7 @@
 
 (defun symex--adjust-point ()
   "Helper to adjust point to indicate the correct symex."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--adjust-point)
     (symex-lisp--adjust-point)))
 
@@ -57,7 +57,7 @@
 
 (defun symex--point-at-root-symex-p ()
   "Check if point is at a root symex."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       ;; note that tree-sitter has a global
       ;; root for the whole file -- that's
       ;; not the one we mean here, but
@@ -67,31 +67,31 @@
 
 (defun symex--point-at-first-symex-p ()
   "Check if point is at the first symex at some level."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--at-first-p)
     (symex-lisp--point-at-first-symex-p)))
 
 (defun symex--point-at-last-symex-p ()
   "Check if point is at the last symex at some level."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--at-last-p)
     (symex-lisp--point-at-last-symex-p)))
 
 (defun symex--point-at-final-symex-p ()
   "Check if point is at the last symex in the buffer."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--at-final-p)
     (symex-lisp--point-at-final-symex-p)))
 
 (defun symex--point-at-initial-symex-p ()
   "Check if point is at the first symex in the buffer."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--at-initial-p)
     (symex-lisp--point-at-initial-symex-p)))
 
 (defun symex--point-at-start-p ()
   "Check if point is at the start of a symex."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--point-at-start-p)
     (symex-lisp--point-at-start-p)))
 
@@ -127,7 +127,7 @@ should be used in all internal operations _above_ the primitive layer
 (e.g. favoring it over Emacs internal utilities like `forward-sexp`)
 that are not primarily user-directed."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-move-next-sibling count)
     (symex-lisp--forward count)))
 
@@ -142,7 +142,7 @@ should be used in all internal operations _above_ the primitive layer
 (e.g. favoring it over Emacs internal utilities like `forward-sexp`)
 that are not primarily user-directed."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-move-prev-sibling count)
     (symex-lisp--backward count)))
 
@@ -157,7 +157,7 @@ should be used in all internal operations _above_ the primitive layer
 (e.g. favoring it over Emacs internal utilities like `forward-sexp`)
 that are not primarily user-directed."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-move-child count)
     (symex-lisp--go-up count)))
 
@@ -172,7 +172,7 @@ should be used in all internal operations _above_ the primitive layer
 (e.g. favoring it over Emacs internal utilities like `forward-sexp`)
 that are not primarily user-directed."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-move-parent count)
     (symex-lisp--go-down count)))
 
@@ -315,13 +315,13 @@ This will always be zero for symex-oriented languages such as Lisp,
 but in languages like Python where the same point position could
 correspond to multiple hierarchy levels, this function computes the
 difference from the lowest such level."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--point-height-offset)
     (symex-lisp--point-height-offset)))
 
 (defun symex--get-starting-point ()
   "Get the point value at the start of the current symex."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--get-starting-point)
     (symex-lisp--get-starting-point)))
 
@@ -330,7 +330,7 @@ difference from the lowest such level."
 
 If the containing expression terminates earlier than COUNT
 symexes, returns the end point of the last one found."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       ;; TODO: implement include-whitespace for ts
       (symex-ts--get-end-point count)
     (symex-lisp--get-end-point count include-whitespace)))
@@ -348,7 +348,7 @@ symexes, returns the end point of the last one found."
 
 (defun symex-select-nearest ()
   "Select symex nearest to point."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-set-current-node-from-point)
     (symex-lisp-select-nearest))
   (point))
@@ -372,7 +372,7 @@ symexes, returns the end point of the last one found."
 (defun symex--primitive-exit ()
   "Take necessary actions as part of exiting Symex mode, at a primitive level."
   (symex--delete-overlay)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-exit)
     (symex-lisp-exit)))
 

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -33,18 +33,6 @@
 (require 'symex-primitives-lisp)
 (require 'symex-ts)
 
-(defvar symex-clojure-modes)
-
-(defun symex-tree-sitter-p ()
-  "Whether to use the tree sitter primitives."
-  (and (and (treesit-available-p) (> (length (treesit-parser-list)) 0))
-       ;; We use the Lisp primitives for Clojure
-       ;; even though Emacs 29 provides tree-sitter APIs
-       ;; for it, since the Lisp primitives in Symex are
-       ;; more mature than the Tree Sitter ones at the
-       ;; present time.
-       (not (member major-mode symex-clojure-modes))))
-
 ;;; User Interface
 
 (defun symex--adjust-point ()
@@ -104,13 +92,13 @@
 
 (defun symex--previous-p ()
   "Check if a preceding symex exists at this level."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--previous-p)
     (symex-lisp--previous-p)))
 
 (defun symex--next-p ()
   "Check if a succeeding symex exists at this level."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--next-p)
     (symex-lisp--next-p)))
 
@@ -204,7 +192,7 @@ that are not primarily user-directed."
 
   ;; fixing leading whitespace in lisp, for now
   ;; probably find a better/uniform way later
-  (unless (symex-tree-sitter-p)
+  (unless (symex-ts-available-p)
     (symex--fix-leading-whitespace))
   ;; fix trailing whitespace (indent region doesn't)
   (symex--fix-trailing-whitespace count)
@@ -225,7 +213,7 @@ from the buffer."
 
 (defun symex--reset-after-delete ()
   "Tidy after deletion and select the appropriate symex."
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts--reset-after-delete)
     (symex-lisp--reset-after-delete)))
 
@@ -277,11 +265,11 @@ WHERE could be either 'before or 'after"
   ;; TODO: remove counts from primitives
   ;; as they aren't used
   (cond ((eq 'before where)
-         (if (symex-tree-sitter-p)
+         (if (symex-ts-available-p)
              (symex-ts-paste-before 1)
            (symex-lisp-paste-before)))
         ((eq 'after where)
-         (if (symex-tree-sitter-p)
+         (if (symex-ts-available-p)
              (symex-ts-paste-after 1)
            (symex-lisp-paste-after)))
         (t (error "Invalid argument for primitive paste!"))))

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -26,8 +26,6 @@
 
 ;;; Code:
 
-(require 'tree-sitter)
-(require 'symex-ts)
 (require 'symex-utils)
 
 (defmacro symex-ts--handle-tree-modification (&rest body)
@@ -76,7 +74,7 @@ selected according to the ranges that have changed."
              (indent-according-to-mode))
 
            ;; Return the result of evaluating BODY
-           ,res)))))
+           ,res))))
 
 (defun symex-ts-clear ()
   "Clear contents of symex."

--- a/symex-transformations-ts.el
+++ b/symex-transformations-ts.el
@@ -53,7 +53,6 @@ selected according to the ranges that have changed."
            (let ((,changed-ranges (tsc-changed-ranges ,prev-tree tree-sitter-tree)))
 
              ;; Move point to the first changed range if possible
-             ;; Move point to the first changed range if possible
              (when (and (> (length ,changed-ranges) 0)
                         (> (length (elt ,changed-ranges 0)) 0))
                (let ((new-pos (elt (elt ,changed-ranges 0) 0)))
@@ -74,7 +73,7 @@ selected according to the ranges that have changed."
              (indent-according-to-mode))
 
            ;; Return the result of evaluating BODY
-           ,res))))
+           ,res)))))
 
 (defun symex-ts-clear ()
   "Clear contents of symex."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -167,28 +167,28 @@
 (symex-define-command symex-emit-backward (count)
   "Emit backward, COUNT times."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-ts-available-p)
       (symex-ts-emit-backward count)
     (symex-lisp-emit-backward count)))
 
 (symex-define-command symex-emit-forward (count)
   "Emit forward, COUNT times."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-ts-available-p)
       (symex-ts-emit-forward count)
     (symex-lisp-emit-forward count)))
 
 (symex-define-command symex-capture-backward (count)
   "Capture backward, COUNT times."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-ts-available-p)
       (symex-ts-capture-backward count)
     (symex-lisp-capture-backward count)))
 
 (symex-define-command symex-capture-forward (count)
   "Capture forward, COUNT times."
   (interactive "p")
-  (if tree-sitter-mode
+  (if (symex-ts-available-p)
       (symex-ts-capture-forward count)
     (symex-lisp-capture-forward count)))
 

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -153,14 +153,14 @@
 (symex-define-insertion-command symex-replace ()
   "Replace contents of symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-replace)
     (symex-lisp-replace)))
 
 (symex-define-command symex-clear ()
   "Clear contents of symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-clear)
     (symex-lisp-clear)))
 
@@ -269,7 +269,7 @@ by default, joins next symex to current one."
 (defun symex-yank (count)
   "Yank (copy) COUNT symexes."
   (interactive "p")
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
     (symex-ts-yank count)
     (symex-lisp-yank count)))
 
@@ -318,42 +318,42 @@ by default, joins next symex to current one."
 (symex-define-insertion-command symex-open-line-after ()
   "Open new line after symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-open-line-after)
     (symex-lisp-open-line-after)))
 
 (symex-define-insertion-command symex-open-line-before ()
   "Open new line before symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-open-line-before)
     (symex-lisp-open-line-before)))
 
 (symex-define-insertion-command symex-append-after ()
   "Append after symex (instead of vim's default of line)."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-append-after)
     (symex-lisp-append-after)))
 
 (symex-define-insertion-command symex-insert-before ()
   "Insert before symex (instead of vim's default at the start of line)."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-insert-before)
     (symex-lisp-insert-before)))
 
 (symex-define-insertion-command symex-insert-at-beginning ()
   "Insert at beginning of symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-insert-at-beginning)
     (symex-lisp-insert-at-beginning)))
 
 (symex-define-insertion-command symex-insert-at-end ()
   "Insert at end of symex."
   (interactive)
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-insert-at-end)
     (symex-lisp-insert-at-end)))
 
@@ -555,7 +555,7 @@ then no action is taken."
 (symex-define-command symex-comment (count)
   "Comment out COUNT symexes."
   (interactive "p")
-  (if (symex-tree-sitter-p)
+  (if (symex-ts-available-p)
       (symex-ts-comment count)
     (progn
       (mark-sexp count)

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -31,8 +31,7 @@
 
 ;;; Code:
 
-(require 'tree-sitter)
-(require 'tsc)
+(defvar symex-clojure-modes)
 
 (defun symex-ts--current-ts-library ()
   "Return a symbol to show what type of tree sitter library is available.
@@ -99,7 +98,14 @@ return nil."
 
 (defun symex-ts-available-p ()
   "Predicate to show if tree sitter support is available to Symex."
-  (and (treesit-available-p) (> (length (treesit-parser-list)) 0)))
+  (and (treesit-available-p)
+       (> (length (treesit-parser-list)) 0)
+       ;; We use the Lisp primitives for Clojure
+       ;; even though Emacs 29 provides tree-sitter APIs
+       ;; for it, since the Lisp primitives in Symex are
+       ;; more mature than the Tree Sitter ones at the
+       ;; present time.
+       (not (member major-mode symex-clojure-modes))))
 
 (defvar-local symex-ts--current-node nil "The current Tree Sitter node.")
 

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -48,9 +48,8 @@ package is being used instead."
   "Initialise tree sitter support for Symex.el."
   (when symex-mode
     (message "Initialising Symex-TS...")
-    (if (eq (symex-ts--current-ts-library) 'internal)
-        (symex-ts--init-treesit-builtin)
-      (symex-ts--init-treesit-package))))
+    (when (eq (symex-ts--current-ts-library) 'internal)
+        (symex-ts--init-treesit-builtin))))
 
 (defun symex-ts--init-treesit-builtin ()
   "Initialise Symex tree sitter support via built-in tree-sitter library."
@@ -94,32 +93,13 @@ return nil."
   (defalias 'symex-ts--root-node #'treesit-buffer-root-node)
   t)
 
-(defun symex-ts--init-treesit-package ()
-  "Initialise Symex tree sitter support via external tree-sitter library."
-  (message "Initialising Symex tree sitter support using external tree-sitter library...")
-  (require 'tree-sitter)
-  (defalias 'symex-ts--count-named-children #'tsc-count-named-children)
-  (defalias 'symex-ts--get-named-descendant-for-position-range #'tsc-get-named-descendant-for-position-range)
-  (defalias 'symex-ts--get-next-named-sibling #'tsc-get-next-named-sibling)
-  (defalias 'symex-ts--get-nth-named-child #'tsc-get-nth-named-child)
-  (defalias 'symex-ts--get-parent #'tsc-get-parent)
-  (defalias 'symex-ts--get-prev-named-sibling #'tsc-get-prev-named-sibling)
-  (defalias 'symex-ts--node-end-position #'tsc-node-end-position)
-  (defalias 'symex-ts--node-eq #'tsc-node-eq)
-  (defalias 'symex-ts--node-start-position #'tsc-node-start-position)
-  (defun 'symex-ts--root-node ()
-    (tsc-root-node tree-sitter-tree))
-  t)
-
 (require 'symex-transformations-ts)
-(require 'symex-utils-ts)
 
 (add-hook 'symex-mode-hook #'symex-ts--init)
 
 (defun symex-ts-available-p ()
   "Predicate to show if tree sitter support is available to Symex."
-  (or (and (treesit-available-p) (> (length (treesit-parser-list)) 0))
-      tree-sitter-mode))
+  (and (treesit-available-p) (> (length (treesit-parser-list)) 0)))
 
 (defvar-local symex-ts--current-node nil "The current Tree Sitter node.")
 

--- a/symex.el
+++ b/symex.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/drym-org/symex.el
 ;; Version: 1.0
-;; Package-Requires: ((emacs "25.1") (tsc "0.15.2") (tree-sitter "0.15.2") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
+;; Package-Requires: ((emacs "25.1") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -46,7 +46,6 @@
 (require 'symex-interface)
 (require 'symex-primitives)
 (require 'symex-custom)
-(require 'tree-sitter)
 (require 'symex-ts)
 
 (defvar symex--original-blink-cursor-state nil)


### PR DESCRIPTION
## Summary of Changes

Incorporate @polaris64 's updates to migrate to Emacs's built-in treesitter.

### Current testing results

**Legend**:
```
[x] = OK
[-] = N/A
[o] = needs design
[ ] = needs fixing
```

**Results**:
```
[x] ("1" digit-argument)
[x] ("2" digit-argument)
[x] ("3" digit-argument)
[x] ("4" digit-argument)
[x] ("5" digit-argument)
[x] ("6" digit-argument)
[x] ("7" digit-argument)
[x] ("8" digit-argument)
[x] ("9" digit-argument)
[x] ("h" symex-go-backward)
[x] ("j" symex-go-down)
[x] ("k" symex-go-up)
[x] ("l" symex-go-forward)
[x] ("gh" backward-char)
[x] ("gj" symex-next-visual-line)
[x] ("gk" symex-previous-visual-line)
[x] ("gl" forward-char)
[x] ("(" symex-create-round)
[x] ("[" symex-create-square)
[ ] (")" symex-wrap-round)
[ ] ("]" symex-wrap-square)
[-] ("C-'" symex-cycle-quote)
[-] ("C-," symex-cycle-unquote)
[-] ("`" symex-add-quoting-level)
[-] ("C-`" symex-remove-quoting-level)
[x] ("f" symex-traverse-forward)
[x] ("b" symex-traverse-backward)
[x] ("C-f" symex-traverse-forward-more)
[x] ("C-b" symex-traverse-backward-more)
[x] ("F" symex-traverse-forward-skip)
[x] ("B" symex-traverse-backward-skip)
[x] ("{" symex-leap-backward)
[x] ("}" symex-leap-forward)
[x] ("M-{" symex-soar-backward)
[x] ("M-}" symex-soar-forward)
[o] ("C-k" symex-climb-branch)
[o] ("C-j" symex-descend-branch)
[x] ("y" symex-yank)
[x] ("Y" symex-yank-remaining)
[ ] ("p" symex-paste-after)
[ ] ("P" symex-paste-before)
[ ] ("x" symex-delete)
[ ] ("X" symex-delete-backwards)
[x] ("c" symex-change)
[ ] ("D" symex-delete-remaining)
[x] ("C" symex-change-remaining)
[ ] ("C--" symex-clear)
[ ] ("s" symex-replace)
[ ] ("-" symex-splice)
[ ] ("S" symex-change-delimiter)
[ ] ("H" symex-shift-backward)
[ ] ("L" symex-shift-forward)
[ ] ("M-H" symex-shift-backward-most)
[ ] ("M-L" symex-shift-forward-most)
[ ] ("K" symex-raise)
[o] ("C-S-j" symex-emit-backward)
[o] ("C-(" symex-capture-backward)
[o] ("C-S-h" symex-capture-backward)
[o] ("C-{" symex-emit-backward)
[o] ("C-S-l" symex-capture-forward)
[o] ("C-}" symex-emit-forward)
[o] ("C-S-k" symex-emit-forward)
[o] ("C-)" symex-capture-forward)
[o] ("z" symex-swallow)
[o] ("Z" symex-swallow-tail)
[o] ("e" symex-evaluate)
[o] ("s-;" symex-evaluate)
[o] ("E" symex-evaluate-remaining)
[-] ("C-M-e" symex-evaluate-pretty)
[o] ("d" symex-evaluate-definition)
[-] ("M-e" symex-eval-recursive)
[-] ("T" symex-evaluate-thunk)
[o] ("t" symex-switch-to-scratch-buffer)
[x] ("M" symex-switch-to-messages-buffer)
[o] ("r" symex-repl)
[o] ("R" symex-run)
[-] ("|" symex-split)
[-] ("&" symex-join)
[ ] ("o" symex-open-line-after)
[ ] ("O" symex-open-line-before)
[x] (">" symex-insert-newline)
[x] ("<" symex-join-lines-backwards)
[x] ("C->" symex-append-newline)
[x] ("C-<" symex-join-lines)
[x] ("C-S-o" symex-append-newline)
[x] ("J" symex-join-lines)
[x] ("M-J" symex-collapse)
[x] ("M-<" symex-collapse)
[x] ("M->" symex-unfurl)
[x] ("C-M-<" symex-collapse-remaining)
[x] ("C-M->" symex-unfurl-remaining)
[x] ("0" symex-goto-first)
[x] ("M-h" symex-goto-first)
[x] ("$" symex-goto-last)
[x] ("M-l" symex-goto-last)
[x] ("M-j" symex-goto-lowest)
[x] ("M-k" symex-goto-highest)
[ ] ("=" symex-tidy)
[ ] ("<tab>" symex-tidy)
[ ] ("C-=" symex-tidy-remaining)
[ ] ("C-<tab>" symex-tidy-remaining)
[ ] ("M-=" symex-tidy-proper)
[ ] ("M-<tab>" symex-tidy-proper)
[o] ("A" symex-append-after)
[o] ("a" symex-insert-at-end)
[o] ("i" symex-insert-at-beginning)
[o] ("I" symex-insert-before)
[o] ("w" symex-wrap)
[o] ("W" symex-wrap-and-append)
[x] (";" symex-comment)
[x] ("M-;" symex-comment-remaining)
[-] ("C-;" symex-eval-print)
[o] ("C-?" symex-describe)
[x] ("<return>" symex-enter-lower)
[x] ("<escape>" symex-escape-higher))
```

### Other todos

- [ ] change usage of `tsc-changed-ranges`, use `treesit-parser-add-notifier`?

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
