### PR TITLE
Remove dependency on evil

### DIFF
--- a/symex-interface-arc.el
+++ b/symex-interface-arc.el
@@ -50,12 +50,6 @@
   (goto-char (point-max))
   (symex-enter-lowest))
 
-(defun symex-switch-to-scratch-buffer-arc ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Arc*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-arc-modes (list 'arc-mode))
 
 (defun symex-interface-register-arc ()
@@ -67,8 +61,7 @@
     :eval-definition #'arc-send-definition
     :eval-pretty #'arc-send-last-sexp
     :eval-thunk #'symex-eval-thunk-arc
-    :repl #'symex-repl-arc
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-arc)))
+    :repl #'symex-repl-arc)))
 
 
 (provide 'symex-interface-arc)

--- a/symex-interface-clojure.el
+++ b/symex-interface-clojure.el
@@ -52,12 +52,6 @@
   (cider-switch-to-repl-buffer)
   (symex-enter-lowest))
 
-(defun symex-switch-to-scratch-buffer-clojure ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Clojure*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-clojure-modes (list 'clojure-mode
                                   'clojurescript-mode
                                   'clojurec-mode))
@@ -73,8 +67,7 @@
     :eval-print #'cider-eval-print-last-sexp
     :describe-symbol #'symex-describe-symbol-clojure
     :repl #'symex-repl-clojure
-    :run #'cider-eval-buffer
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-clojure)))
+    :run #'cider-eval-buffer)))
 
 (provide 'symex-interface-clojure)
 ;;; symex-interface-clojure.el ends here

--- a/symex-interface-common-lisp.el
+++ b/symex-interface-common-lisp.el
@@ -92,12 +92,6 @@ Accounts for different point location in evil vs Emacs mode."
       (sly-eval-buffer)
     (slime-eval-buffer)))
 
-(defun symex-switch-to-scratch-buffer-common-lisp ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Common Lisp*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-common-lisp-modes (list 'lisp-mode
                                       'slime-repl-mode
                                       'sly-mrepl-mode))
@@ -113,8 +107,7 @@ Accounts for different point location in evil vs Emacs mode."
     :eval-print #'symex-eval-print-common-lisp
     :describe-symbol #'symex-describe-symbol-common-lisp
     :repl #'symex-repl-common-lisp
-    :run #'symex-run-common-lisp
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-common-lisp)))
+    :run #'symex-run-common-lisp)))
 
 
 (provide 'symex-interface-common-lisp)

--- a/symex-interface-elisp.el
+++ b/symex-interface-elisp.el
@@ -57,9 +57,6 @@ open in most recently used other window."
            (split-window-right)
            (windmove-right)
            (ielm))
-          ((symex--evil-installed-p)
-           (evil-window-mru)            ; better LRU
-           (ielm))
           (t
            (other-window -1)
            (ielm)))

--- a/symex-interface-elisp.el
+++ b/symex-interface-elisp.el
@@ -63,12 +63,6 @@ open in most recently used other window."
     (goto-char (point-max))
     (symex-enter-lowest)))
 
-(defun symex-switch-to-scratch-buffer-elisp ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-elisp-modes (list 'lisp-interaction-mode
                                 'emacs-lisp-mode
                                 'inferior-emacs-lisp-mode))
@@ -84,8 +78,7 @@ open in most recently used other window."
     :eval-print #'symex-eval-print-elisp
     :describe-symbol #'symex-describe-symbol-elisp
     :repl #'symex-repl-elisp
-    :run #'eval-buffer
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-elisp)))
+    :run #'eval-buffer)))
 
 (provide 'symex-interface-elisp)
 ;;; symex-interface-elisp.el ends here

--- a/symex-interface-elisp.el
+++ b/symex-interface-elisp.el
@@ -25,7 +25,7 @@
 
 ;;; Code:
 
-(require 'evil)
+(require 'evil nil :no-error)
 (require 'symex-interop)
 (require 'symex-interface)
 
@@ -54,11 +54,15 @@ open in most recently used other window."
   (let ((window (get-buffer-window "*ielm*")))
     (cond (window (select-window window))
           ((= 1 (length (window-list)))
-           (evil-window-vsplit)
-           (evil-window-right 1)
+           (split-window-right)
+           (windmove-right)
            (ielm))
-          (t (evil-window-mru)  ; better LRU
-             (ielm)))
+          ((symex--evil-installed-p)
+           (evil-window-mru)            ; better LRU
+           (ielm))
+          (t
+           (other-window -1)
+           (ielm)))
     (goto-char (point-max))
     (symex-enter-lowest)))
 

--- a/symex-interface-fennel.el
+++ b/symex-interface-fennel.el
@@ -55,12 +55,6 @@
   "Evaluate buffer."
   (lisp-eval-region (point-min) (point-max)))
 
-(defun symex-switch-to-scratch-buffer-fennel ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Fennel*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-fennel-modes (list 'fennel-mode))
 
 (defun symex-interface-register-fennel ()
@@ -73,8 +67,7 @@
     :eval-thunk #'symex-eval-thunk-fennel
     :describe-symbol #'fennel-find-definition
     :repl #'symex-repl-fennel
-    :run #'symex-run-fennel
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-fennel)))
+    :run #'symex-run-fennel)))
 
 (provide 'symex-interface-fennel)
 ;;; symex-interface-fennel.el ends here

--- a/symex-interface-racket.el
+++ b/symex-interface-racket.el
@@ -74,10 +74,7 @@ Based on `racket--send-region-to-repl' from `racket-mode'."
   "Eval last sexp.
 
 Accounts for different point location in evil vs Emacs mode."
-  (save-excursion
-    (when (equal evil-state 'normal)
-      (forward-char))
-    (racket-send-last-sexp)))
+  (racket-send-last-sexp))
 
 (defun symex-eval-pretty-racket ()
   "Evaluate symex and render the result in a useful string form."

--- a/symex-interface-racket.el
+++ b/symex-interface-racket.el
@@ -118,12 +118,6 @@ Accounts for different point location in evil vs Emacs mode."
       (goto-char (point-max))
       (symex-enter-lowest))))
 
-(defun symex-switch-to-scratch-buffer-racket ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Racket*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-racket-modes (list 'racket-mode
                                  'racket-repl-mode))
 
@@ -138,8 +132,7 @@ Accounts for different point location in evil vs Emacs mode."
     :eval-thunk #'symex-eval-thunk-racket
     :describe-symbol #'symex-describe-symbol-racket
     :repl #'symex-repl-racket
-    :run #'racket-run
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-racket)))
+    :run #'racket-run)))
 
 (provide 'symex-interface-racket)
 ;;; symex-interface-racket.el ends here

--- a/symex-interface-scheme.el
+++ b/symex-interface-scheme.el
@@ -53,12 +53,6 @@
   "Evaluate buffer."
   (geiser-eval-buffer nil))
 
-(defun symex-switch-to-scratch-buffer-scheme ()
-  "Switch to scratch buffer."
-  (let ((buffer-name "*scratch - Scheme*"))
-    (switch-to-buffer (or (get-buffer buffer-name)
-                          (symex--new-scratch-buffer buffer-name)))))
-
 (defvar symex-scheme-modes (list 'scheme-mode))
 
 (defun symex-interface-register-scheme ()
@@ -71,8 +65,7 @@
     :eval-pretty #'symex-eval-scheme
     :describe-symbol #'geiser-doc-symbol-at-point
     :repl #'symex-repl-scheme
-    :run #'symex-run-scheme
-    :switch-to-scratch-buffer #'symex-switch-to-scratch-buffer-scheme)))
+    :run #'symex-run-scheme)))
 
 (provide 'symex-interface-scheme)
 ;;; symex-interface-scheme.el ends here

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -132,18 +132,6 @@ right symex when we enter Symex mode."
   (setq-local scroll-margin symex--original-scroll-margin)
   (setq-local maximum-scroll-margin symex--original-max-scroll-margin))
 
-(defun symex--evil-scroll-down ()
-  "Scroll down half a page.
-
-This is needed because symex alters scroll margins upon mode entry to
-ensure that the symex is always in focus.  For some reason this winds
-up causing evil's `evil-scroll-down` to scroll all the way to the
-bottom of the buffer.  So we temporarily override the scroll margin in
-executing this command to get the expected behavior."
-  (interactive)
-  (let ((scroll-margin 0))
-    (evil-scroll-down nil)))
-
 
 (provide 'symex-interop)
 ;;; symex-interop.el ends here

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -35,9 +35,12 @@
 (defvar chimera-symex-mode)
 (defvar rigpa-mode)
 
-;; stub out evil-state in case evil is not installed.
-(when (not (boundp 'evil-state))
-  (setq evil-state nil))
+;; temporary stubbing non-evil modal users
+(when (not (boundp 'evil))
+  (setq evil-state nil)
+  (defun evil-emacslike-state ())
+  (defun evil-normallike-state ())
+  (defun evil-nil-state ()))
 
 ;; misc bindings defined elsewhere
 (declare-function rigpa-enter-higher-level "ext:ignore")
@@ -89,7 +92,9 @@ right symex when we enter Symex mode."
         ((symex--evil-enabled-p)
          (evil-normal-state))
         ((symex--evil-installed-p)
-         (evil-emacs-state))))
+         (evil-emacs-state))
+        ((fboundp 'symex-user-defined-higher-mode)
+         (symex-user-defined-higher-mode))))
 
 (defun symex-enter-lower ()
   "Exit symex mode via an \"enter\"."
@@ -99,7 +104,9 @@ right symex when we enter Symex mode."
         ((symex--evil-enabled-p)
          (evil-insert-state))
         ((symex--evil-installed-p)
-         (evil-emacs-state))))
+         (evil-emacs-state))
+        ((fboundp 'symex-user-defined-lower-mode)
+         (symex-user-defined-lower-mode))))
 
 (defun symex-enter-lowest ()
   "Enter the lowest (manual) editing level."
@@ -109,7 +116,9 @@ right symex when we enter Symex mode."
         ((symex--evil-enabled-p)
          (evil-insert-state))
         ((symex--evil-installed-p)
-         (evil-emacs-state))))
+         (evil-emacs-state))
+        ((fboundp 'symex-user-defined-lowest-mode)
+         (symex-user-defined-lowest-mode))))
 
 (defun symex--set-scroll-margin ()
   "Set a convenient scroll margin for symex mode, after storing the original value."

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -37,10 +37,7 @@
 
 ;; temporary stubbing non-evil modal users
 (when (not (boundp 'evil))
-  (setq evil-state nil)
-  (defun evil-emacslike-state ())
-  (defun evil-normallike-state ())
-  (defun evil-nil-state ()))
+  (setq evil-state nil))
 
 ;; misc bindings defined elsewhere
 (declare-function rigpa-enter-higher-level "ext:ignore")

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -27,13 +27,17 @@
 
 ;;; Code:
 
-(require 'symex-custom
-         'symex-primitives)
+(require 'symex-custom)
+(require 'symex-primitives)
 
 ;; to avoid byte compile warnings.  eventually sort out the dependency
 ;; order so this is unnecessary
 (defvar chimera-symex-mode)
 (defvar rigpa-mode)
+
+;; stub out evil-state in case evil is not installed.
+(when (not (boundp 'evil-state))
+  (setq evil-state nil))
 
 ;; misc bindings defined elsewhere
 (declare-function rigpa-enter-higher-level "ext:ignore")
@@ -84,7 +88,8 @@ right symex when we enter Symex mode."
          (rigpa-enter-higher-level))
         ((symex--evil-enabled-p)
          (evil-normal-state))
-        (t (evil-emacs-state))))
+        ((symex--evil-installed-p)
+         (evil-emacs-state))))
 
 (defun symex-enter-lower ()
   "Exit symex mode via an \"enter\"."
@@ -93,7 +98,8 @@ right symex when we enter Symex mode."
          (rigpa-enter-lower-level))
         ((symex--evil-enabled-p)
          (evil-insert-state))
-        (t (evil-emacs-state))))
+        ((symex--evil-installed-p)
+         (evil-emacs-state))))
 
 (defun symex-enter-lowest ()
   "Enter the lowest (manual) editing level."
@@ -102,7 +108,8 @@ right symex when we enter Symex mode."
          (rigpa-enter-lowest-level))
         ((symex--evil-enabled-p)
          (evil-insert-state))
-        (t (evil-emacs-state))))
+        ((symex--evil-installed-p)
+         (evil-emacs-state))))
 
 (defun symex--set-scroll-margin ()
   "Set a convenient scroll margin for symex mode, after storing the original value."

--- a/symex-lithium.el
+++ b/symex-lithium.el
@@ -146,7 +146,6 @@
    ("I" symex-insert-before)
    ("w" symex-wrap)
    ("W" symex-wrap-and-append)
-   ("C-d" symex--evil-scroll-down)
    (";" symex-comment)
    ("M-;" symex-comment-remaining)
    ("C-;" symex-eval-print) ; weird pre-offset (in both)

--- a/symex-lithium.el
+++ b/symex-lithium.el
@@ -108,7 +108,6 @@
    ("d" symex-evaluate-definition)
    ("M-e" symex-eval-recursive)
    ("T" symex-evaluate-thunk)
-   ("t" symex-switch-to-scratch-buffer)
    ("r" symex-repl)
    ("R" symex-run)
    ("|" symex-split)

--- a/symex-lithium.el
+++ b/symex-lithium.el
@@ -109,7 +109,6 @@
    ("M-e" symex-eval-recursive)
    ("T" symex-evaluate-thunk)
    ("t" symex-switch-to-scratch-buffer)
-   ("M" symex-switch-to-messages-buffer)
    ("r" symex-repl)
    ("R" symex-run)
    ("|" symex-split)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -156,14 +156,6 @@ Version 2017-11-01"
   (interactive)
   (funcall (symex-interface-get-method :switch-to-scratch-buffer)))
 
-(defun symex-switch-to-messages-buffer ()
-  "Switch to messages buffer while retaining focus in original window."
-  (interactive)
-  (switch-to-buffer-other-window "*Messages*")
-  (goto-char (point-max))
-  (recenter)
-  (evil-window-mru))
-
 (defun symex-user-select-nearest ()
   "Select symex nearest to point.
 

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -151,11 +151,6 @@ Version 2017-11-01"
       (setq buffer-offer-save nil))
     $buf))
 
-(defun symex-switch-to-scratch-buffer ()
-  "Switch to scratch buffer."
-  (interactive)
-  (funcall (symex-interface-get-method :switch-to-scratch-buffer)))
-
 (defun symex-user-select-nearest ()
   "Select symex nearest to point.
 

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -26,7 +26,7 @@
 ;;; Code:
 
 
-(require 'evil)
+(require 'evil nil :no-error)
 (require 'symex-primitives)
 (require 'symex-evaluator)
 (require 'symex-computations)
@@ -48,17 +48,18 @@
 ;;; MISCELLANEOUS ;;;
 ;;;;;;;;;;;;;;;;;;;;;
 
-(evil-define-state emacslike
-  "An Emacs-like state."
-  :tag " <E> "
-  :message "-- EMACHS --"
-  :enable (emacs))
+(when (symex--evil-installed-p)
+  (evil-define-state emacslike
+    "An Emacs-like state."
+    :tag " <E> "
+    :message "-- EMACHS --"
+    :enable (emacs))
 
-(evil-define-state normallike
-  "A Normal-like state."
-  :tag " <N> "
-  :message "-- NORMALE --"
-  :enable (normal))
+  (evil-define-state normallike
+    "A Normal-like state."
+    :tag " <N> "
+    :message "-- NORMALE --"
+    :enable (normal)))
 
 (defun symex--evaluate ()
   "Evaluate symex."

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -211,7 +211,7 @@ This does *not* include the current symex."
 This moves down COUNT lines in terms of buffer coordinates, rather than
 structurally in terms of the tree."
   (interactive "p")
-  (evil-next-visual-line count)
+  (next-line count)
   (symex-select-nearest-in-line))
 
 (defun symex-previous-visual-line (&optional count)
@@ -220,7 +220,7 @@ structurally in terms of the tree."
 This moves up COUNT lines in terms of buffer coordinates, rather than
 structurally in terms of the tree."
   (interactive "p")
-  (evil-previous-visual-line count)
+  (previous-line count)
   (symex-select-nearest-in-line))
 
 (defun symex-soar-backward (count)

--- a/symex-misc.el
+++ b/symex-misc.el
@@ -27,6 +27,7 @@
 
 
 (require 'evil nil :no-error)
+(require 'symex-custom)
 (require 'symex-primitives)
 (require 'symex-evaluator)
 (require 'symex-computations)
@@ -35,11 +36,6 @@
 (require 'symex-interface-builtins)
 (require 'symex-interop)
 (require 'symex-ui)
-
-;; These are customization or config variables defined elsewhere;
-;; explicitly indicating them here to avoid byte compile warnings
-(defvar symex-refocus-p)
-(defvar symex-highlight-p)
 
 ;; buffer-local branch memory stack
 (defvar-local symex--branch-memory nil)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -678,7 +678,7 @@ line."
              (symex--join-to-next)
            ;; don't leave an empty line where the symex was
            (symex--delete-whole-line)))
-        ((or (save-excursion (evil-last-non-blank) ; (<>$
+        ((or (save-excursion (symex-last-non-blank) ; (<>$
                              (symex-left-p)))
          (symex--join-to-next))
         ((looking-at-p "\n")         ; (abc <>
@@ -704,7 +704,7 @@ line."
                    ;; ensure that there isn't a comment on the
                    ;; preceding line before joining lines
                    (unless (condition-case nil
-                               (save-excursion (evil-find-char 1 ?\;)
+                               (save-excursion (re-search-forward ";" (line-end-position))
                                                t)
                              (error nil))
                      (symex--join-to-match symex--re-right))))))))

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -31,6 +31,7 @@
 
 
 (require 'paredit)
+(require 'evil nil :no-error)
 (require 'symex-data)
 (require 'symex-utils)
 (require 'symex-interface)

--- a/symex-primitives.el
+++ b/symex-primitives.el
@@ -388,6 +388,12 @@ symexes, returns the end point of the last one found."
         (fixup-whitespace))
     (error nil)))
 
+(defun symex-last-non-blank ()
+  "Go to last non-blank character on line."
+  (end-of-line)
+  (skip-chars-backward " \t")
+  (unless (bolp) (backward-char)))
+
 (defun symex--primitive-enter ()
   "Take necessary actions as part of entering Symex mode, at a primitive level."
   (if (symex-ts-available-p)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -28,8 +28,6 @@
 (require 'cl-lib)
 
 (require 'paredit)
-(require 'evil)
-(require 'evil-surround)
 (require 'symex-primitives)
 (require 'symex-primitives-lisp)
 (require 'symex-utils)

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -76,7 +76,7 @@
   (newline-and-indent)
   (forward-line -1)
   (indent-according-to-mode)
-  (move-end-of-line)
+  (move-end-of-line 1)
   (unless (or (symex--current-line-empty-p)
               (save-excursion (backward-char)
                               (symex-left-p)))

--- a/symex-transformations-lisp.el
+++ b/symex-transformations-lisp.el
@@ -76,7 +76,7 @@
   (newline-and-indent)
   (forward-line -1)
   (indent-according-to-mode)
-  (evil-move-end-of-line)
+  (move-end-of-line)
   (unless (or (symex--current-line-empty-p)
               (save-excursion (backward-char)
                               (symex-left-p)))

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -612,7 +612,8 @@ then no action is taken."
          (start (point-marker))
          (end (save-excursion (forward-sexp) (point-marker))))
     (if no-trim
-        (save-excursion (symex--surround open-delimiter close-delimiter start end))
+        (save-excursion
+          (symex--surround open-delimiter close-delimiter start end))
       (save-excursion
         (goto-char start)
         (delete-char 1)

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -30,8 +30,7 @@
 (require 'symex-transformations-lisp)
 (require 'symex-transformations-ts)
 
-(require 'evil)
-(require 'evil-surround)
+(require 'evil nil :no-error)
 (require 'symex-misc)
 (require 'symex-primitives)
 (require 'symex-primitives-lisp)
@@ -101,7 +100,8 @@ function as repeatable via `evil-repeat'."
      (defun ,name ,args
        ,docstring
        ,interactive-decl
-       (evil-start-undo-step)
+       (when (symex--evil-installed-p)
+         (evil-start-undo-step))
        ,@body
        (symex-enter-lowest))
      (evil-add-command-properties ',name :repeat t)))
@@ -295,7 +295,8 @@ by default, joins next symex to current one."
 (symex-define-command symex-paste-before (count)
   "Paste before symex, COUNT times."
   (interactive "p")
-  (setq this-command 'evil-paste-before)
+  (when (symex--evil-installed-p)
+    (setq this-command 'evil-paste-before))
   ;; typically (e.g. to follow the convention in evil), we
   ;; want to select the start of the pasted text after
   ;; pasting.
@@ -314,7 +315,8 @@ by default, joins next symex to current one."
 (symex-define-command symex-paste-after (count)
   "Paste after symex, COUNT times."
   (interactive "p")
-  (setq this-command 'evil-paste-after)
+  (when (symex--evil-installed-p)
+    (setq this-command 'evil-paste-after))
   ;; TODO: user-level defcustom of whether to move
   ;; to indicate pasted text (like evil), which should
   ;; be checked here and appropriately applied. E.g.
@@ -443,6 +445,21 @@ in the parent symex."
       (symex-ts--not-implemented)
     (symex-lisp-raise)))
 
+(defun symex--delete-pair ()
+  "Delete a pair of characters enclosing sexps that follow point."
+  (save-excursion
+    (skip-chars-forward " \t")
+    (save-excursion
+      (let ((open-char (char-after)))
+        (forward-sexp)
+        (unless (member (list open-char (char-before))
+                        (mapcar (lambda (p)
+                                  (if (= (length p) 3) (cdr p) p))
+                                insert-pair-alist))
+          (error "Not before matching pair"))
+        (delete-char -1)))
+    (delete-char 1)))
+
 (symex-define-command symex-splice ()
   "Splice or \"clip\" symex.
 
@@ -450,17 +467,13 @@ If the symex is a nested list, this operation eliminates the symex,
 putting its contents in the parent symex.  If the symex is an atom,
 then no action is taken."
   (interactive)
-  (unless (symex-atom-p)
-    ;; in treesitter, non-atoms need not be lists,
-    ;; but we only want to splice lists, for now
-    (when (symex-left-p)
-      (let ((start (point))
-            (end (symex--get-end-point 1)))
-        (symex--transform-in-isolation start end
-          (goto-char (point-min))
-          (delete-char 1)
-          (goto-char (1- (point-max)))
-          (delete-char 1))))))
+  (when (or (symex-left-p) (symex-lisp-string-p))
+    (if (or (symex-empty-list-p)
+            (symex-empty-string-p))
+        (symex-delete 1)
+      (save-excursion
+        (symex--delete-pair)
+        (symex--go-down)))))
 
 (defun symex--wrap-with (left right)
   "Wrap selected symex with LEFT and RIGHT."
@@ -583,13 +596,37 @@ then no action is taken."
                 (= row (line-number-at-pos)))
       (symex--shift-forward))))
 
+(defvar symex--delimiters
+  '(("(" . ")") ("[" . "]") ("{" . "}") ("<" . ">") ("\"" . "\"")))
+
+(defun symex--surround (open-delimiter close-delimiter start end)
+  (goto-char end)
+  (insert close-delimiter)
+  (goto-char start)
+  (insert open-delimiter))
+
+(defun symex--change-delimiter (&optional no-trim)
+  (let* ((open-delimiter (completing-read "Choose opening delimiter: " (mapcar 'car symex--delimiters)))
+         (close-delimiter (or (cdr (assoc open-delimiter symex--delimiters))
+                              open-delimiter))
+         (start (point-marker))
+         (end (save-excursion (forward-sexp) (point-marker))))
+    (if no-trim
+        (save-excursion (symex--surround open-delimiter close-delimiter start end))
+      (save-excursion
+        (goto-char start)
+        (delete-char 1)
+        (insert open-delimiter)
+        (goto-char (1- end))
+        (delete-char 1)
+        (insert close-delimiter)))))
+
 (symex-define-command symex-change-delimiter ()
   "Change delimiter enclosing current symex, e.g. round -> square brackets."
   (interactive)
   (if (or (symex-left-p) (symex-lisp-string-p))
-      (evil-surround-change (following-char))
-    (let ((bounds (bounds-of-thing-at-point 'sexp)))
-      (evil-surround-region (car bounds) (cdr bounds) 'inclusive 40))))
+      (symex--change-delimiter)
+    (symex--change-delimiter :no-trim)))
 
 (symex-define-command symex-comment (count)
   "Comment out COUNT symexes."

--- a/symex-transformations.el
+++ b/symex-transformations.el
@@ -86,7 +86,8 @@ function as repeatable via `evil-repeat'."
            ;; were made.
            (symex--tidy 1)
            ,result))
-       (evil-add-command-properties ',name :repeat t))))
+       (when (symex--evil-installed-p)
+         (evil-add-command-properties ',name :repeat t)))))
 
 (defmacro symex-define-insertion-command (name
                                           args
@@ -104,7 +105,8 @@ function as repeatable via `evil-repeat'."
          (evil-start-undo-step))
        ,@body
        (symex-enter-lowest))
-     (evil-add-command-properties ',name :repeat t)))
+     (when (symex--evil-installed-p)
+       (evil-add-command-properties ',name :repeat t))))
 
 (defun symex--delete (count)
   "Delete COUNT symexes."

--- a/symex.el
+++ b/symex.el
@@ -3,7 +3,7 @@
 ;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
 ;; URL: https://github.com/drym-org/symex.el
 ;; Version: 1.0
-;; Package-Requires: ((emacs "25.1") (paredit "24") (evil "1.2.14") (evil-surround "1.0.4") (seq "2.22"))
+;; Package-Requires: ((emacs "25.1") (paredit "24") (seq "2.22"))
 ;; Keywords: lisp, convenience, languages
 
 ;; This program is "part of the world," in the sense described at
@@ -40,10 +40,12 @@
 ;;; Code:
 
 (require 'symex-lithium)
-(require 'symex-evil)
+(when (symex--evil-installed-p)
+  (require 'symex-evil))
 (require 'symex-interop)
 (require 'symex-misc)
 (require 'symex-interface)
+(require 'symex-transformations)
 (require 'symex-primitives)
 (require 'symex-custom)
 (require 'symex-ts)

--- a/symex.el
+++ b/symex.el
@@ -147,7 +147,8 @@ advises functions to enable or disable features based on user configuration."
   ;; initialize modal interface frontend
   (symex-modal-provider-initialize)
   ;; initialize repeat command and other evil interop
-  (symex-initialize-evil)
+  (when (symex--evil-installed-p)
+    (symex-initialize-evil))
   (symex-ts--init))
 
 (defun symex-disable ()
@@ -169,7 +170,8 @@ configuration to be disabled and the new one adopted."
   (advice-remove #'symex-go-up #'symex--return-to-branch-position)
   (advice-remove #'symex-go-backward #'symex--forget-branch-positions)
   (advice-remove #'symex-go-forward #'symex--forget-branch-positions)
-  (symex-disable-evil)
+  (when (symex--evil-installed-p)
+    (symex-disable-evil))
   (symex--remove-selection-advice))
 
 ;;;###autoload

--- a/symex.el
+++ b/symex.el
@@ -40,9 +40,9 @@
 ;;; Code:
 
 (require 'symex-lithium)
+(require 'symex-interop)
 (when (symex--evil-installed-p)
   (require 'symex-evil))
-(require 'symex-interop)
 (require 'symex-misc)
 (require 'symex-interface)
 (require 'symex-transformations)


### PR DESCRIPTION
### Summary of Changes

Incorporate @devcarbon-com 's work to remove a hard dependency on Evil, from #118 .

There are still some uses of evil that are baked in and which we can't yet put behind a flag. Grepping the project folder for `evil-` shows all such uses of Evil. It should mostly be a matter of replacing each of these functions with built-in Emacs equivalents.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
