### PR TITLE
Decompose to modular packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Installation
     (symex-initialize)
     (global-set-key (kbd "s-;") 'symex-mode-interface))  ; or whatever keybinding you like
 
-This provides a keybinding to load the symex editing interface, and also enables the symex minor mode in all recognized lisp modes (the minor mode ensures that manual edits respect the tree structure, e.g. keeps parens balanced like paredit).
+This provides a keybinding to load the symex editing interface, and also enables the ``symex-lisp`` minor mode in all recognized lisp modes (the minor mode ensures that manual edits respect the tree structure, e.g. keeps parens balanced like paredit).
 
 Documentation
 =============
@@ -452,7 +452,7 @@ In writing Lisp code, parentheses are among the most commonly typed characters, 
 ::
 
    (define-key
-     symex-mode-map
+     symex-lisp-mode-map
      (kbd "C-w")
      (lambda ()
        (interactive)

--- a/doc/symex.texi
+++ b/doc/symex.texi
@@ -699,7 +699,7 @@ In writing Lisp code, parentheses are among the most commonly typed characters, 
 
 @lisp
 (define-key
-  symex-mode-map
+  symex-lisp-mode-map
   (kbd "C-w")
   (lambda ()
     (interactive)

--- a/doc/symex.texi
+++ b/doc/symex.texi
@@ -1424,7 +1424,7 @@ Don't hesitate to add print statements (e.g., @code{print} or @code{message}) to
 
 @subheading Disable Advice
 
-Symex uses @uref{https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html, advice} to implement some features such as adding a selection overlay. To minimize complexity while debugging, it may be advisable (so to speak) in certain cases to disable such advice. To do this, find the place in the code where the advice is added, and execute the corresponding function to remove it. Something like, @code{(advice-remove #'symex-user-select-nearest #'symex--selection-side-effects)}. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation!
+Symex uses @uref{https://www.gnu.org/software/emacs/manual/html_node/elisp/Advising-Functions.html, advice} to implement some features such as adding a selection overlay. To minimize complexity while debugging, it may be advisable (so to speak) in certain cases to disable such advice. To do this, find the place in the code where the advice is added, and execute the corresponding function to remove it. Something like, @code{(advice-remove #'symex-user-select-nearest #'symex-mode-highlight-selected)}. Of course, if disabling the advice causes the error to go away, then you can focus your efforts on debugging the advice itself in isolation!
 
 @subheading Comment Out Macros
 

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -55,28 +55,5 @@
   :type '(repeat string)
   :group 'symex)
 
-(defcustom symex-lisp-modes (list 'clojure-mode
-                                  'clojurescript-mode
-                                  'clojurec-mode)
-  "List of major modes that should use the Lisp rather than Treesitter parser.
-
-In cases where treesitter isn't available, the Lisp parser would be
-used at any rate, but this option allows you to override the use of
-Treesitter for modes where you'd prefer to use the Lisp parser even
-though treesitter is available.
-
-The Lisp parser has some differences from the Treesitter parser,
-including not treating comments as symexes."
-  :type '(repeat symbol)
-  :group 'symex)
-
-(defcustom symex-common-lisp-backend 'slime
-  "Backend provider for Common Lisp interactive features.  One of:
-
-  - SLIME: The Superior Lisp Interaction Mode for Emacs.
-  - SLY: Sylvestors Common Lisp IDE for Emacs.  A fork of SLIME."
-  :type 'symbol
-  :group 'symex)
-
 (provide 'symex-custom)
 ;;; symex-custom.el ends here

--- a/symex-custom.el
+++ b/symex-custom.el
@@ -27,18 +27,8 @@
 
 
 (defgroup symex nil
-  "A language for editing symbolic expressions."
+  "An expressive modal way to edit code."
   :group 'lisp)
-
-(defcustom symex-highlight-p t
-  "Whether selected symexes should be highlighted."
-  :type 'boolean
-  :group 'symex)
-
-(defcustom symex-refocus-p t
-  "Whether to refocus on the selected symex when it's near the screen's edge."
-  :type 'boolean
-  :group 'symex)
 
 (defcustom symex-ensure-structure-p t
   "Whether to balance parentheses in Lisp modes."

--- a/symex-evil.el
+++ b/symex-evil.el
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+;; NOTE: this module is part of symex-mode
 (require 'evil nil :no-error)
 (require 'symex-motions)
 (require 'symex-lithium)

--- a/symex-interop.el
+++ b/symex-interop.el
@@ -27,6 +27,7 @@
 
 ;;; Code:
 
+;; NOTE: this module should be part of symex-mode
 (require 'evil nil :no-error)
 (require 'symex-custom)
 (require 'symex-primitives)

--- a/symex-mode.el
+++ b/symex-mode.el
@@ -1,0 +1,149 @@
+;;; symex.el --- An evil way to edit Lisp symbolic expressions as trees -*- lexical-binding: t -*-
+
+;; Author: Siddhartha Kasivajhula <sid@countvajhula.com>
+;; URL: https://github.com/drym-org/symex.el
+;; Version: 1.0
+;; Package-Requires: ((emacs "25.1") (paredit "24") (seq "2.22") (lithium "0.1.1"))
+;; Keywords: lisp, convenience, languages
+
+;; This program is "part of the world," in the sense described at
+;; https://drym.org.  From your perspective, this is no different than
+;; MIT or BSD or other such "liberal" licenses that you may be
+;; familiar with, that is to say, you are free to do whatever you like
+;; with this program.  It is much more than BSD or MIT, however, in
+;; that it isn't a license at all but an idea about the world and how
+;; economic systems could be set up so that everyone wins.  Learn more
+;; at drym.org.
+;;
+;; This work transcends traditional legal and economic systems, but
+;; for the purposes of any such systems within which you may need to
+;; operate:
+;;
+;; This is free and unencumbered software released into the public domain.
+;; The authors relinquish any copyright claims on this work.
+;;
+
+;;; Commentary:
+
+;; Symex mode (pronounced sym-ex, as in symbolic expression) is a vim-
+;; inspired way of editing Lisp code as trees.  Entering symex mode
+;; allows you to reason about your code in terms of its structure,
+;; similar to other tools like paredit and lispy.  But while in those
+;; packages the tree representation is implicit, symex mode models
+;; the tree structure explicitly so that tree navigations and operations
+;; can be described using an expressive DSL, and invoked in a vim-
+;; style modal interface.
+;;
+;; Under the hood, Symex mode uses paredit and Tree-Sitter for parsing
+;; the code syntax tree.
+
+;;; Code:
+
+(require 'symex-motions)
+(require 'symex-tree)
+(require 'symex-custom)
+
+;; TODO: for primitive-entry/exit
+;; eliminate, in favor of a ts minor mode.
+(require 'symex-primitives)
+
+(require 'symex-lithium)
+(require 'symex-repeat)
+(require 'symex-runtime)
+(require 'symex-ui)
+(require 'symex-interop)
+
+(defgroup symex-mode nil
+  "Point-free modal UI for Symex."
+  :group 'symex)
+
+(defcustom symex-highlight-p t
+  "Whether selected symexes should be highlighted."
+  :type 'boolean
+  :group 'symex-mode)
+
+(defcustom symex-refocus-p t
+  "Whether to refocus on the selected symex when it's near the screen's edge."
+  :type 'boolean
+  :group 'symex-mode)
+
+(defun symex-mode-highlight-selected (&rest _)
+  "Things to do as part of symex selection, e.g. after navigations."
+  (when symex-highlight-p
+    (symex--update-overlay)))
+
+(defun symex--enter-mode ()
+  "Load the modal interface."
+  (symex-editing-mode-enter))
+
+;; TODO: put a lot of this in entry hooks
+(defun symex-enter-mode ()
+  "Take necessary action upon symex mode entry."
+  (add-hook 'symex-selection-hook
+            #'symex-mode-highlight-selected)
+  (symex--adjust-point-on-entry)
+  (when symex-remember-branch-positions-p
+    (symex--clear-branch-memory))
+  (symex-user-select-nearest)
+  ;; TODO: this concept of primitive entry should be removed.
+  ;; it enables the change notifier mainly, and we should
+  ;; instead do that via a symex-treesit-mode, perhaps
+  (symex--primitive-enter)
+  ;; enable parsing for repeat functionality
+  (symex-repeat-enable)
+  (when symex-refocus-p
+    ;; smooth scrolling currently not supported
+    ;; may add it back in the future
+    (symex--set-scroll-margin))
+  (symex--enter-mode))
+
+(defun symex-exit-mode ()
+  "Take necessary action upon symex mode exit."
+  (remove-hook 'symex-selection-hook
+               #'symex-mode-highlight-selected)
+  (when symex-refocus-p
+    (symex--restore-scroll-margin))
+  (symex--delete-overlay)
+  (symex--primitive-exit)
+  ;; if we are exiting as part of a repeatable action
+  ;; then don't suspend the symex repeat parser
+  (unless (member symex--current-keys symex-repeatable-keys)
+    (symex-repeat-disable)))
+
+(defun symex-modal-provider-initialize ()
+  "Initialize the modal interface provider."
+  (symex-lithium-initialize))
+
+;;;###autoload
+(defun symex-modal-initialize ()
+  "Initialize the modal interface."
+  ;; any side effects that should happen as part of selection,
+  ;; e.g., update overlay
+  ;; TODO: are these still needed with the selection hook in place?
+  (advice-add #'symex-user-select-nearest :after #'symex-mode-highlight-selected)
+  (advice-add #'symex-select-nearest-in-line :after #'symex-mode-highlight-selected)
+  ;; initialize modal interface provider
+  (symex-modal-provider-initialize)
+  ;; initialize repeat command and evil interop
+  (symex-repeat-initialize)
+  ;; initialize runtime integrations with various language backends
+  (symex-runtime-initialize))
+
+(defun symex-modal-disable ()
+  "Disable symex modal interface."
+  ;; remove all advice
+  (advice-remove #'symex-user-select-nearest #'symex-mode-highlight-selected)
+  (advice-remove #'symex-select-nearest-in-line #'symex-mode-highlight-selected)
+  (symex-repeat-teardown))
+
+;;;###autoload
+(defun symex-mode-interface ()
+  "The main entry point for editing symbolic expressions using symex mode.
+
+Enter the symex evil state, activating symex keybindings."
+  (interactive)
+  (symex-enter-mode))
+
+
+(provide 'symex-mode)
+;;; symex-mode.el ends here

--- a/symex-mode.el
+++ b/symex-mode.el
@@ -119,9 +119,6 @@
   "Initialize the modal interface."
   ;; any side effects that should happen as part of selection,
   ;; e.g., update overlay
-  ;; TODO: are these still needed with the selection hook in place?
-  (advice-add #'symex-user-select-nearest :after #'symex-mode-highlight-selected)
-  (advice-add #'symex-select-nearest-in-line :after #'symex-mode-highlight-selected)
   ;; initialize modal interface provider
   (symex-modal-provider-initialize)
   ;; initialize repeat command and evil interop
@@ -132,8 +129,6 @@
 (defun symex-modal-disable ()
   "Disable symex modal interface."
   ;; remove all advice
-  (advice-remove #'symex-user-select-nearest #'symex-mode-highlight-selected)
-  (advice-remove #'symex-select-nearest-in-line #'symex-mode-highlight-selected)
   (symex-repeat-teardown))
 
 ;;;###autoload

--- a/symex-motions.el
+++ b/symex-motions.el
@@ -33,6 +33,9 @@
 (require 'symex-tree)
 (require 'symex-interop)
 
+(defvar symex-selection-hook nil
+  "Hook run whenever a symex is selected.")
+
 ;; TODO: these "selection" functions aren't motions; maybe they ought
 ;; to be filed in another module (`symex-user`?)
 (defun symex-user-select-nearest ()
@@ -48,7 +51,8 @@ This also may entail hooks and advice, which would be absent in the
 primitive version."
   (interactive)
   (unless (symex--selected-p)
-    (symex-select-nearest)))
+    (symex-select-nearest)
+    (run-hooks 'symex-selection-hook)))
 
 (defun symex-select-nearest-in-line ()
   "Select symex nearest to point that's on the current line."
@@ -58,10 +62,8 @@ primitive version."
       (symex-select-nearest)
       (unless (= (line-number-at-pos)
                  (line-number-at-pos original-pos))
-        (goto-char original-pos)))))
-
-(defvar symex-selection-hook nil
-  "Hook run whenever a symex is selected.")
+        (goto-char original-pos))
+      (run-hooks 'symex-selection-hook))))
 
 (defmacro symex-define-motion (name
                                args

--- a/symex-motions.el
+++ b/symex-motions.el
@@ -87,7 +87,7 @@ BODY - the actual implementation of the motion."
          ,docstring
          ,interactive-decl
          (let ((,result (progn ,@body)))
-           (run-hooks symex-selection-hook)
+           (run-hooks 'symex-selection-hook)
            ,result)))))
 
 (symex-define-motion symex-go-forward (count)

--- a/symex-motions.el
+++ b/symex-motions.el
@@ -32,7 +32,6 @@
 (require 'symex-traversals)
 (require 'symex-tree)
 (require 'symex-interop)
-(require 'symex-ui)
 
 ;; TODO: these "selection" functions aren't motions; maybe they ought
 ;; to be filed in another module (`symex-user`?)
@@ -61,10 +60,8 @@ primitive version."
                  (line-number-at-pos original-pos))
         (goto-char original-pos)))))
 
-(defun symex--selection-side-effects (&rest _)
-  "Things to do as part of symex selection, e.g. after navigations."
-  (when symex-highlight-p
-    (symex--update-overlay)))
+(defvar symex-selection-hook nil
+  "Hook run whenever a symex is selected.")
 
 (defmacro symex-define-motion (name
                                args
@@ -90,7 +87,7 @@ BODY - the actual implementation of the motion."
          ,docstring
          ,interactive-decl
          (let ((,result (progn ,@body)))
-           (symex--selection-side-effects)
+           (run-hooks symex-selection-hook)
            ,result)))))
 
 (symex-define-motion symex-go-forward (count)

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -36,9 +36,6 @@
 (require 'symex-utils)
 (require 'symex-interface)
 
-(declare-function symex-mode "symex.el")
-(defvar symex-mode)
-
 ;;;;;;;;;;;;;;;;;;
 ;;; PRIMITIVES ;;;
 ;;;;;;;;;;;;;;;;;;

--- a/symex-primitives-lisp.el
+++ b/symex-primitives-lisp.el
@@ -722,15 +722,9 @@ symex or after it."
 
 ;;; Utilities
 
-(defun symex--ensure-minor-mode ()
-  "Enable symex minor mode if it isn't already enabled."
-  (unless symex-mode
-    (symex-mode)))
-
 (defun symex-lisp-enter ()
   "Take necessary actions upon Symex mode entry in Lisp modes."
-  (when (member major-mode (symex-get-lisp-modes))
-    (symex--ensure-minor-mode)))
+  nil)
 
 (defun symex-lisp-exit ()
   "Take necessary actions upon Symex mode exit.

--- a/symex-runtime.el
+++ b/symex-runtime.el
@@ -31,6 +31,30 @@
 (require 'symex-traversals)
 (require 'symex-tree)
 (require 'symex-interface)
+(require 'symex-interface-builtins)
+
+(defcustom symex-lisp-modes (list 'clojure-mode
+                                  'clojurescript-mode
+                                  'clojurec-mode)
+  "List of major modes that should use the Lisp rather than Treesitter parser.
+
+In cases where treesitter isn't available, the Lisp parser would be
+used at any rate, but this option allows you to override the use of
+Treesitter for modes where you'd prefer to use the Lisp parser even
+though treesitter is available.
+
+The Lisp parser has some differences from the Treesitter parser,
+including not treating comments as symexes."
+  :type '(repeat symbol)
+  :group 'symex)
+
+(defcustom symex-common-lisp-backend 'slime
+  "Backend provider for Common Lisp interactive features.  One of:
+
+  - SLIME: The Superior Lisp Interaction Mode for Emacs.
+  - SLY: Sylvestors Common Lisp IDE for Emacs.  A fork of SLIME."
+  :type 'symbol
+  :group 'symex)
 
 (defun symex--evaluate ()
   "Evaluate symex."

--- a/symex-runtime.el
+++ b/symex-runtime.el
@@ -143,5 +143,9 @@ executing it."
   (interactive)
   (funcall (symex-interface-get-method :run)))
 
+(defun symex-runtime-initialize ()
+  "Initialize runtime integration for symex mode."
+  (symex-register-builtin-interfaces))
+
 (provide 'symex-runtime)
 ;;; symex-runtime.el ends here

--- a/symex-runtime.el
+++ b/symex-runtime.el
@@ -31,7 +31,6 @@
 (require 'symex-traversals)
 (require 'symex-tree)
 (require 'symex-interface)
-(require 'symex-ui)
 
 (defun symex--evaluate ()
   "Evaluate symex."

--- a/symex-ts.el
+++ b/symex-ts.el
@@ -158,6 +158,9 @@ return nil."
        ;; for it, since the Lisp primitives in Symex are
        ;; more mature than the Tree Sitter ones at the
        ;; present time.
+       ;; TODO: I don't think this is needed anymore,
+       ;; as clojure-mode doesn't use tree-sitter anyway
+       ;; and clojure-ts-mode cannot use the lisp parser anyway
        (not (member major-mode symex-lisp-modes))))
 
 (defvar-local symex-ts--current-node nil "The current Tree Sitter node.")

--- a/symex.el
+++ b/symex.el
@@ -42,7 +42,6 @@
 (require 'symex-evil)
 (require 'symex-motions)
 (require 'symex-tree)
-(require 'symex-interface-builtins)
 (require 'symex-transformations)
 (require 'symex-primitives)
 (require 'symex-custom)

--- a/symex.el
+++ b/symex.el
@@ -96,7 +96,6 @@
 This registers symex mode for use in all recognized Lisp modes, and also
 advises functions to enable or disable features based on user configuration."
 
-  (symex-register-builtin-interfaces)
   ;; enable the symex minor mode in all recognized lisp modes
   (when symex-ensure-structure-p
     (dolist (mode-name (symex-get-lisp-modes))

--- a/symex.el
+++ b/symex.el
@@ -47,9 +47,8 @@
 (require 'symex-custom)
 (require 'symex-ts)
 
-;; TODO: rename this to symex-lisp-mode or symex-balance-paren-mode
 ;;;###autoload
-(define-minor-mode symex-mode
+(define-minor-mode symex-lisp-mode
   "An evil way to edit Lisp symbolic expressions as trees."
   :lighter " symex"
   :keymap (let ((symex-map (make-sparse-keymap)))
@@ -103,7 +102,7 @@ advises functions to enable or disable features based on user configuration."
     (dolist (mode-name (symex-get-lisp-modes))
       (let ((mode-hook (intern (concat (symbol-name mode-name)
                                        "-hook"))))
-        (add-hook mode-hook #'symex-mode))))
+        (add-hook mode-hook #'symex-lisp-mode))))
   (when (symex--evil-installed-p)
     (symex-initialize-evil))
   (symex-ts--init))
@@ -122,7 +121,7 @@ configuration to be disabled and the new one adopted."
     (dolist (mode-name (symex-get-lisp-modes))
       (let ((mode-hook (intern (concat (symbol-name mode-name)
                                        "-hook"))))
-        (remove-hook mode-hook 'symex-mode))))
+        (remove-hook mode-hook 'symex-lisp-mode))))
   (when (symex--evil-installed-p)
     (symex-disable-evil)))
 


### PR DESCRIPTION
### Summary of Changes

Decompose Symex into modular packages. Might as well do this as part of Symex 2.0, while we wait on MELPA review.

Addresses #26 .

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
