### PR TITLE
Improved highlight face

### DIFF
--- a/symex/doc/symex.texi
+++ b/symex/doc/symex.texi
@@ -784,7 +784,7 @@ Alternatively you can use Elisp to set the face programmatically. Using @code{se
 (set-face-attribute 'symex-highlight-face nil :extend t :inherit '(italic region))
 @end lisp
 
-WARNING: @code{set-face-attribute} will only set the attributes you tell it to. It does not clear attributes that are already set. This means that if you play around with it, you can end up with something that looks different from what you would get running the latest thing from a clean slate. This won't be a problem once your configuration is ready and Emacs is just running it when it starts up, but keep it in mind as you try things out.
+@strong{Warning:} @code{set-face-attribute} will only set the attributes you tell it to. It does not clear attributes that are already set. This means that if you play around with it, you can end up with something that looks different from what you would get running the latest thing from a clean slate. This won't be a problem once your configuration is ready and Emacs is just running it when it starts up, but keep it in mind as you try things out.
 
 You can also eval a @code{defface} form to set the entire face specification, though that can interfere with documentation or groups is anything has changed.
 
@@ -799,19 +799,19 @@ Some quick tips: You can use the @code{describe-face} command to see lots of dif
 
 Here are some basic options that you could try:
 
-Underline: It is very compatible across different themes. If you want something that is guaranteed to be readable and not interfere with highlighting this is a good choice.
+@strong{Underline}: It is very compatible across different themes. If you want something that is guaranteed to be readable and not interfere with highlighting this is a good choice.
 
 @lisp
 (set-face-attribute 'symex-highlight-face nil :extend nil :underline t :inherit '(underline))
 @end lisp
 
-Italic + Region: Uses the normal region face (the one used when you mark/select a region of text) but with italics to visually set it apart from the former use. It is readable and works with syntax highlighting in many themes and is the default.
+@strong{Italic + Region}: Uses the normal region face (the one used when you mark/select a region of text) but with italics to visually set it apart from the former use. It is readable and works with syntax highlighting in many themes and is the default.
 
 @lisp
 (set-face-attribute 'symex-highlight-face nil :extend nil :inherit '(italic region))
 @end lisp
 
-Highlight: The legacy default. In many themes it is a bolder color (sometimes to the extent that it becomes hard to read). It also sets the foreground in some themes; thus, breaking syntax highlighting.
+@strong{Highlight}: The legacy default. In many themes it is a bolder color (sometimes to the extent that it becomes hard to read). It also sets the foreground in some themes; thus, breaking syntax highlighting.
 
 @lisp
 (set-face-attribute 'symex-highlight-face nil :extend nil :inherit '(highlight))

--- a/symex/doc/symex.texi
+++ b/symex/doc/symex.texi
@@ -776,6 +776,47 @@ The current expression is highlighted by default using an overlay. If you'd like
 (symex-highlight-p nil)
 @end lisp
 
+You can also customize the face used for this by configuring the @code{symex-highlight-face}. This can be done using the Customize interface (accessible by @code{M-x customize}; @xref{Easy Customization,,,emacs, the GNU Emacs manual} also @xref{Face Customization,,,emacs, the GNU Emacs manual}).
+
+Alternatively you can use Elisp to set the face programmatically. Using @code{set-face-attribute} will allow you to change any attribute of the face. For example, this sets Symex's highlight face to inherit from the italic and region faces and to extend the face all the way to the edge of the window when selecting over multiple lines.
+
+@lisp
+(set-face-attribute 'symex-highlight-face nil :extend t :inherit '(italic region))
+@end lisp
+
+WARNING: @code{set-face-attribute} will only set the attributes you tell it to. It does not clear attributes that are already set. This means that if you play around with it, you can end up with something that looks different from what you would get running the latest thing from a clean slate. This won't be a problem once your configuration is ready and Emacs is just running it when it starts up, but keep it in mind as you try things out.
+
+You can also eval a @code{defface} form to set the entire face specification, though that can interfere with documentation or groups is anything has changed.
+
+@lisp
+(defface symex-highlight-face
+  '((nil :extend nil :inherit (italic region)))
+  "Face used to highlight the current ."
+  :group 'symex-faces)
+@end lisp
+
+Some quick tips: You can use the @code{describe-face} command to see lots of different faces and then @code{:inherit} from one(s) you like. If you choose a standard face like @code{region}, @code{highlight}, or @code{underline} it will use the face definition from your theme. Finally, if you want to still see code highlighting, make sure that your face does not set the foreground color as that will cause the overlay override the foreground property set by the highlighter.
+
+Here are some basic options that you could try:
+
+Underline: It is very compatible across different themes. If you want something that is guaranteed to be readable and not interfere with highlighting this is a good choice.
+
+@lisp
+(set-face-attribute 'symex-highlight-face nil :extend nil :underline t :inherit '(underline))
+@end lisp
+
+Italic + Region: Uses the normal region face (the one used when you mark/select a region of text) but with italics to visually set it apart from the former use. It is readable and works with syntax highlighting in many themes and is the default.
+
+@lisp
+(set-face-attribute 'symex-highlight-face nil :extend nil :inherit '(italic region))
+@end lisp
+
+Highlight: The legacy default. In many themes it is a bolder color (sometimes to the extent that it becomes hard to read). It also sets the foreground in some themes; thus, breaking syntax highlighting.
+
+@lisp
+(set-face-attribute 'symex-highlight-face nil :extend nil :inherit '(highlight))
+@end lisp
+
 @node Point Placement on Entry
 @section Point Placement on Entry
 

--- a/symex/symex-ui.el
+++ b/symex/symex-ui.el
@@ -37,12 +37,12 @@
   :group 'symex-mode)
 
 (defface symex-highlight-face
-  '((t :extend nil :inherit (italic region)))
+  '((nil :extend nil :inherit (italic region)))
   "Face used to highlight symexes."
   :group 'symex-faces)
 
 (defcustom symex-highlight-face
-  '((t :extend nil :inherit (italic region)))
+  '((nil :extend nil :inherit (italic region)))
   "Face used to highlight symexes."
   :type 'face
   :group 'symex-faces)

--- a/symex/symex-ui.el
+++ b/symex/symex-ui.el
@@ -36,9 +36,15 @@
   :type 'boolean
   :group 'symex-mode)
 
-(defface symex--current-node-face
-  '((t :inherit highlight :extend nil))
-  "Face used to highlight the current tree node."
+(defface symex-highlight-face
+  '((t :extend nil :inherit (italic region)))
+  "Face used to highlight symexes."
+  :group 'symex-faces)
+
+(defcustom symex-highlight-face
+  '((t :extend nil :inherit (italic region)))
+  "Face used to highlight symexes."
+  :type 'face
   :group 'symex-faces)
 
 (defvar symex--current-overlay nil "The current overlay which highlights the current node.")
@@ -58,7 +64,7 @@
                 (error start))))
     (setq-local symex--current-overlay
                 (make-overlay start end)))
-  (overlay-put symex--current-overlay 'face 'symex--current-node-face))
+  (overlay-put symex--current-overlay 'face 'symex-highlight-face))
 
 (defun symex--overlay-active-p ()
   "Is the overlay active?"


### PR DESCRIPTION
### Summary of Changes

I created `symex-highlight-face`, made a `defcustom` so that people can use that interface to customize it, switched the highlight functionality over to using `sumex-highlight-face`, and updated the manual with a section on customizing the face.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
