### PR TITLE
Update symex selection after every command in editing mode

### DIFF
--- a/symex/symex-lithium.el
+++ b/symex/symex-lithium.el
@@ -151,7 +151,14 @@
    ("<return>" symex-enter-lower :exit)
    ("<escape>" symex-escape-higher :exit))
   :lighter " symex"
-  :group 'symex)
+  :group 'symex
+
+  ;; Enable mode
+  (when symex-editing-mode
+    (add-hook 'post-command-hook #'symex-user-select-nearest-idempotent nil :local))
+  ;; Disable mode
+  (when (not symex-editing-mode)
+    (remove-hook 'post-command-hook #'symex-user-select-nearest-idempotent t)))
 
 
 (provide 'symex-lithium)


### PR DESCRIPTION
### Summary of Changes

Added `symex-user-select-nearest-idempotent` to `post-command-hook` locally while `symex-editing-mode` is active.

In practice this means that interactive commands outside of Symex that move the point around will automatically update the Symex selection. This gives better integration with external commands. 

Previously external commands could move the point and you would not see the Symex selection update until after moving using Symex.

This resolves #67 and #168 and partially addresses #48 (in that it provides more integration with external tools like Avy but does not provide a full replacement of Lispy's Avy commands).

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
